### PR TITLE
feat: surface Bit Indie branding on landing page

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 import { CatalogGrid } from "../components/catalog/catalog-grid";
 import { listCatalogGames } from "../lib/api";
 
@@ -11,6 +13,16 @@ export default async function HomePage(): Promise<JSX.Element> {
 
       <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-16">
         <section className="space-y-6 text-center">
+          <div className="flex justify-center">
+            <Image
+              src="/bit-indie-logo.svg"
+              alt="Bit Indie logo"
+              width={220}
+              height={220}
+              priority
+              className="drop-shadow-[0_20px_45px_rgba(139,92,246,0.35)]"
+            />
+          </div>
           <p className="text-[0.65rem] font-semibold uppercase tracking-[0.55em] text-emerald-300/70">
             Bit Indie marketplace
           </p>

--- a/apps/web/public/bit-indie-logo.svg
+++ b/apps/web/public/bit-indie-logo.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Bit Indie Logo</title>
+  <desc id="desc">A purple Bitcoin symbol inside a circle to the left of the words Bit Indie.</desc>
+  <rect width="512" height="512" rx="40" fill="#0b0b0d" />
+  <circle cx="156" cy="256" r="108" fill="#8b5cf6" />
+  <text
+    x="156"
+    y="270"
+    text-anchor="middle"
+    font-size="120"
+    font-family="'DM Sans', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-weight="700"
+    fill="#0b0b0d"
+  >₿</text>
+  <text
+    x="310"
+    y="220"
+    font-size="96"
+    font-family="'DM Sans', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-weight="700"
+    letter-spacing="0.22em"
+    fill="#8b5cf6"
+  >BIT</text>
+  <text
+    x="310"
+    y="330"
+    font-size="96"
+    font-family="'DM Sans', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-weight="700"
+    letter-spacing="0.22em"
+    fill="#8b5cf6"
+  >INDIE</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a branded Bit Indie logo asset under the public directory
- surface the logo above the hero copy on the storefront landing page for immediate brand recognition

## Testing
- npm run lint (apps/web)


------
https://chatgpt.com/codex/tasks/task_e_68d44a546a30832b892247c70adca9ce