### PR TITLE
Update landing screen selector labels

### DIFF
--- a/apps/web/components/landing/sections/screen-switcher.tsx
+++ b/apps/web/components/landing/sections/screen-switcher.tsx
@@ -5,10 +5,10 @@ import type { Dispatch, SetStateAction } from "react";
 import { cn } from "./shared";
 
 const SCREEN_OPTIONS = [
-  { label: "Storefront", value: 1 },
-  { label: "Sell your game", value: 2 },
-  { label: "Lightning checkout", value: 3 },
-  { label: "Receipt flow", value: 4 },
+  { label: "Catalog", value: 1 },
+  { label: "Sell Your Game", value: 2 },
+  { label: "Info for Players", value: 3 },
+  { label: "Chat", value: 4 },
 ] as const;
 
 function uppercaseLabel(value: string): string {


### PR DESCRIPTION
## Summary
- update the landing screen switcher labels to Catalog, Sell Your Game, Info for Players, and Chat

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddff4e6af0832b822daa7cca804fdd