### PR TITLE
feat: expand landing coverage and document workflows

### DIFF
--- a/CODEBASE_HEALTH_REPORT.md
+++ b/CODEBASE_HEALTH_REPORT.md
@@ -1,0 +1,21 @@
+# Bit Indie Codebase Health Report
+
+## Architecture & Organization
+- The backend follows a classic FastAPI service layout with a dedicated application factory and modular routers, keeping concerns well separated and making dependency injection straightforward.【F:apps/api/src/bit_indie_api/main.py†L1-L42】
+- Core domain logic sits in service layers such as `GameDraftingService`, which encapsulate validations, dependency wiring, and side effects behind clear docstrings and focused methods. This makes business rules discoverable and easier to test in isolation.【F:apps/api/src/bit_indie_api/services/game_drafting.py†L1-L135】
+- The Next.js storefront keeps API access behind typed client helpers and funnels landing-page logic through a single `NeonLanding` component, which composes smaller presentation sections for clarity.【F:apps/web/app/page.tsx†L1-L39】【F:apps/web/components/landing/neon-landing.tsx†L1-L185】
+
+## Code Quality & Patterns
+- Backend modules consistently use typed dataclasses, custom exceptions, and docstrings to communicate intent. Price validation, slug enforcement, and Lightning address requirements are enforced centrally rather than in routes, reducing duplication.【F:apps/api/src/bit_indie_api/services/game_drafting.py†L36-L134】
+- Frontend utilities such as `lib/format.ts` provide shared formatting helpers with documented options, avoiding inline string manipulation throughout the UI.【F:apps/web/lib/format.ts†L1-L102】
+- Data fetching on the landing page cleanly separates catalog and featured loads with error guards, surfacing a `hadLoadFailure` banner without crashing the UI.【F:apps/web/app/page.tsx†L14-L39】【F:apps/web/components/landing/neon-landing.tsx†L125-L185】
+
+## Test Coverage & Tooling
+- The FastAPI layer has extensive pytest suites that spin up isolated in-memory databases, assert domain errors, and exercise service orchestration, demonstrating a healthy focus on regression safety.【F:apps/api/tests/test_services_game_drafting.py†L1-L125】
+- Node-based unit tests cover the Next.js data clients, mocking `fetch` and validating error handling paths so the web app enforces request contracts.【F:apps/web/lib/api/comments.test.ts†L1-L79】
+- The web package ships with TypeScript compilation for tests and lint/build scripts wired through the workspace, signaling a thoughtful developer experience even before E2E coverage is introduced.【F:apps/web/package.json†L1-L24】【F:apps/web/tsconfig.test.json†L1-L27】
+
+## Opportunities
+- Consider expanding frontend test coverage beyond API clients to include critical UI logic (e.g., the landing screen state machine) with component tests or story-driven assertions.
+- The catalog loader currently logs errors to the server console; capturing these events with a shared telemetry hook would improve observability across both web and API layers.
+- As the project grows, documenting cross-service workflows (purchase lifecycle, moderation) in `docs/` could help onboard contributors faster by pairing prose with the existing strong service abstractions.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 import NeonLanding from "../components/landing/neon-landing";
 import { getFeaturedGames, listCatalogGames } from "../lib/api";
 import type { FeaturedGameSummary, GameDraft } from "../lib/api/games";
+import { recordLandingDataLoadFailure } from "../lib/telemetry";
 
 type CatalogLoadResult = {
   games: GameDraft[];
@@ -18,6 +19,7 @@ async function loadCatalog(): Promise<CatalogLoadResult> {
     return { games, failed: false };
   } catch (error) {
     console.error("Failed to load catalog games", error);
+    recordLandingDataLoadFailure("catalog", error);
     return { games: [], failed: true };
   }
 }
@@ -28,6 +30,7 @@ async function loadFeatured(): Promise<FeaturedLoadResult> {
     return { summaries, failed: false };
   } catch (error) {
     console.error("Failed to load featured games", error);
+    recordLandingDataLoadFailure("featured", error);
     return { summaries: [], failed: true };
   }
 }

--- a/apps/web/components/landing/landing-screen-machine.test.ts
+++ b/apps/web/components/landing/landing-screen-machine.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LANDING_SCREEN_SEQUENCE,
+  landingScreenReducer,
+  type LandingScreen,
+  type LandingScreenEvent,
+} from "./landing-screen-machine";
+
+function runEvents(initial: LandingScreen, events: LandingScreenEvent[]): LandingScreen {
+  return events.reduce(landingScreenReducer, initial);
+}
+
+test("landingScreenReducer selects an explicit screen", () => {
+  const initial = LANDING_SCREEN_SEQUENCE[0];
+  const nextState = landingScreenReducer(initial, { type: "SELECT", screen: 3 });
+  assert.equal(nextState, 3);
+});
+
+test("landingScreenReducer ignores duplicate selections", () => {
+  const initial = LANDING_SCREEN_SEQUENCE[1];
+  const nextState = landingScreenReducer(initial, { type: "SELECT", screen: initial });
+  assert.equal(nextState, initial);
+});
+
+test("landingScreenReducer advances through the landing flow", () => {
+  const finalState = runEvents(LANDING_SCREEN_SEQUENCE[0], [
+    { type: "NEXT" },
+    { type: "NEXT" },
+    { type: "NEXT" },
+  ]);
+  assert.equal(finalState, LANDING_SCREEN_SEQUENCE[LANDING_SCREEN_SEQUENCE.length - 1]);
+});
+
+test("landingScreenReducer does not advance past the final screen", () => {
+  const initial = LANDING_SCREEN_SEQUENCE[LANDING_SCREEN_SEQUENCE.length - 1];
+  const nextState = landingScreenReducer(initial, { type: "NEXT" });
+  assert.equal(nextState, initial);
+});
+
+test("landingScreenReducer walks backwards through the landing flow", () => {
+  const startingState = LANDING_SCREEN_SEQUENCE[3];
+  const finalState = runEvents(startingState, [
+    { type: "PREVIOUS" },
+    { type: "PREVIOUS" },
+  ]);
+  assert.equal(finalState, LANDING_SCREEN_SEQUENCE[1]);
+});
+
+test("landingScreenReducer clamps selections outside of the known sequence", () => {
+  const initial = LANDING_SCREEN_SEQUENCE[1];
+  const belowRange = landingScreenReducer(initial, { type: "SELECT", screen: 0 as LandingScreen });
+  assert.equal(belowRange, LANDING_SCREEN_SEQUENCE[0]);
+
+  const aboveRange = landingScreenReducer(initial, { type: "SELECT", screen: 42 as LandingScreen });
+  assert.equal(aboveRange, LANDING_SCREEN_SEQUENCE[LANDING_SCREEN_SEQUENCE.length - 1]);
+});

--- a/apps/web/components/landing/landing-screen-machine.ts
+++ b/apps/web/components/landing/landing-screen-machine.ts
@@ -1,0 +1,71 @@
+import { useReducer } from "react";
+
+export const LANDING_SCREEN_SEQUENCE = [1, 2, 3, 4] as const;
+
+export type LandingScreen = (typeof LANDING_SCREEN_SEQUENCE)[number];
+
+type SelectScreenEvent = { type: "SELECT"; screen: LandingScreen };
+type NextScreenEvent = { type: "NEXT" };
+type PreviousScreenEvent = { type: "PREVIOUS" };
+
+export type LandingScreenEvent = SelectScreenEvent | NextScreenEvent | PreviousScreenEvent;
+
+function clampScreen(value: number): LandingScreen {
+  if (value <= LANDING_SCREEN_SEQUENCE[0]) {
+    return LANDING_SCREEN_SEQUENCE[0];
+  }
+
+  if (value >= LANDING_SCREEN_SEQUENCE[LANDING_SCREEN_SEQUENCE.length - 1]) {
+    return LANDING_SCREEN_SEQUENCE[LANDING_SCREEN_SEQUENCE.length - 1];
+  }
+
+  return value as LandingScreen;
+}
+
+function getNextScreen(current: LandingScreen): LandingScreen {
+  const index = LANDING_SCREEN_SEQUENCE.indexOf(current);
+  const next = LANDING_SCREEN_SEQUENCE[index + 1];
+  return next ?? current;
+}
+
+function getPreviousScreen(current: LandingScreen): LandingScreen {
+  const index = LANDING_SCREEN_SEQUENCE.indexOf(current);
+  const previous = LANDING_SCREEN_SEQUENCE[index - 1];
+  return previous ?? current;
+}
+
+export function landingScreenReducer(
+  state: LandingScreen,
+  event: LandingScreenEvent,
+): LandingScreen {
+  switch (event.type) {
+    case "SELECT": {
+      if (event.screen === state) {
+        return state;
+      }
+      return clampScreen(event.screen);
+    }
+    case "NEXT":
+      return getNextScreen(state);
+    case "PREVIOUS":
+      return getPreviousScreen(state);
+    default:
+      return state;
+  }
+}
+
+export function useLandingScreenMachine(initialScreen: LandingScreen = LANDING_SCREEN_SEQUENCE[0]): {
+  activeScreen: LandingScreen;
+  selectScreen: (screen: LandingScreen) => void;
+  goToNextScreen: () => void;
+  goToPreviousScreen: () => void;
+} {
+  const [activeScreen, dispatch] = useReducer(landingScreenReducer, initialScreen);
+
+  return {
+    activeScreen,
+    selectScreen: (screen: LandingScreen) => dispatch({ type: "SELECT", screen }),
+    goToNextScreen: () => dispatch({ type: "NEXT" }),
+    goToPreviousScreen: () => dispatch({ type: "PREVIOUS" }),
+  };
+}

--- a/apps/web/components/landing/neon-landing.tsx
+++ b/apps/web/components/landing/neon-landing.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import type { FeaturedGameSummary, GameDraft } from "../../lib/api/games";
 import { formatCategory, formatDateLabel } from "../../lib/format";
@@ -10,6 +10,7 @@ import {
   FALLBACK_FEATURED,
   FALLBACK_INVOICE_STEPS,
 } from "./landing-fallbacks";
+import { useLandingScreenMachine } from "./landing-screen-machine";
 import {
   buildChecklist,
   buildDescriptionFromMarkdown,
@@ -87,7 +88,7 @@ function computeHeroMetrics(
 }
 
 export default function NeonLanding({ catalogGames, featuredSummaries, hadLoadFailure }: NeonLandingProps): JSX.Element {
-  const [activeScreen, setActiveScreen] = useState<number>(1);
+  const { activeScreen, selectScreen } = useLandingScreenMachine();
 
   const summaryMap = useMemo(() => buildSummaryMap(featuredSummaries), [featuredSummaries]);
 
@@ -153,7 +154,7 @@ export default function NeonLanding({ catalogGames, featuredSummaries, hadLoadFa
             </div>
             <AccountAccessWidget />
           </div>
-          <ScreenSwitcher activeScreen={activeScreen} onSelect={setActiveScreen} />
+          <ScreenSwitcher activeScreen={activeScreen} onSelect={selectScreen} />
         </header>
         <main className="space-y-10 pb-16">
           {activeScreen === 1 && (

--- a/apps/web/components/landing/sections/screen-switcher.tsx
+++ b/apps/web/components/landing/sections/screen-switcher.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
+import type { LandingScreen } from "../landing-screen-machine";
 
 import { cn } from "./shared";
 
-const SCREEN_OPTIONS = [
+const SCREEN_OPTIONS: ReadonlyArray<{ label: string; value: LandingScreen }> = [
   { label: "Storefront", value: 1 },
   { label: "Sell your game", value: 2 },
   { label: "Lightning checkout", value: 3 },
   { label: "Receipt flow", value: 4 },
-] as const;
+];
 
 function uppercaseLabel(value: string): string {
   return value.toUpperCase();
@@ -19,8 +19,8 @@ export function ScreenSwitcher({
   activeScreen,
   onSelect,
 }: {
-  activeScreen: number;
-  onSelect: Dispatch<SetStateAction<number>>;
+  activeScreen: LandingScreen;
+  onSelect: (screen: LandingScreen) => void;
 }): JSX.Element {
   return (
     <div className="flex flex-wrap gap-3">

--- a/apps/web/lib/telemetry.test.ts
+++ b/apps/web/lib/telemetry.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import * as Sentry from "@sentry/nextjs";
+
+import { captureWebException, recordLandingDataLoadFailure } from "./telemetry";
+
+type FakeScopeRecord = {
+  extras: Record<string, unknown>;
+  tags: Record<string, string>;
+  level?: string;
+};
+
+class FakeScope {
+  public record: FakeScopeRecord = { extras: {}, tags: {} };
+
+  setExtra(key: string, value: unknown): void {
+    this.record.extras[key] = value;
+  }
+
+  setTag(key: string, value: string): void {
+    this.record.tags[key] = value;
+  }
+
+  setLevel(level: string): void {
+    this.record.level = level;
+  }
+}
+
+type MutableSentry = {
+  withScope: (callback: (scope: Sentry.Scope) => void) => void;
+  captureException: (error: unknown) => unknown;
+};
+
+test("captureWebException annotates Sentry scope", () => {
+  const mutableSentry = Sentry as unknown as MutableSentry;
+  const originalWithScope = mutableSentry.withScope;
+  const originalCaptureException = mutableSentry.captureException;
+
+  const fakeScope = new FakeScope();
+  let capturedError: Error | undefined;
+
+  mutableSentry.withScope = (callback) => {
+    callback(fakeScope as unknown as Sentry.Scope);
+  };
+
+  mutableSentry.captureException = (error) => {
+    capturedError = error as Error;
+    return "capture-id";
+  };
+
+  try {
+    captureWebException("failure", { feature: "test", attempt: 2 });
+  } finally {
+    mutableSentry.withScope = originalWithScope;
+    mutableSentry.captureException = originalCaptureException;
+  }
+
+  assert.ok(capturedError);
+  assert.equal(capturedError?.message, "failure");
+  assert.equal(fakeScope.record.tags.surface, "web");
+  assert.equal(fakeScope.record.level, "error");
+  assert.equal(fakeScope.record.extras.feature, "test");
+  assert.equal(fakeScope.record.extras.attempt, 2);
+});
+
+test("recordLandingDataLoadFailure enriches telemetry", () => {
+  const mutableSentry = Sentry as unknown as MutableSentry;
+  const originalWithScope = mutableSentry.withScope;
+  const originalCaptureException = mutableSentry.captureException;
+
+  const fakeScope = new FakeScope();
+  let capturedError: Error | undefined;
+
+  mutableSentry.withScope = (callback) => {
+    callback(fakeScope as unknown as Sentry.Scope);
+  };
+
+  mutableSentry.captureException = (error) => {
+    capturedError = error as Error;
+    return "capture-id";
+  };
+
+  try {
+    recordLandingDataLoadFailure("catalog", new Error("catalog failed"), { requestId: "req-123" });
+  } finally {
+    mutableSentry.withScope = originalWithScope;
+    mutableSentry.captureException = originalCaptureException;
+  }
+
+  assert.ok(capturedError);
+  assert.equal(capturedError?.message, "catalog failed");
+  assert.equal(fakeScope.record.tags.surface, "web");
+  assert.equal(fakeScope.record.extras.feature, "landing");
+  assert.equal(fakeScope.record.extras.dataset, "catalog");
+  assert.equal(fakeScope.record.extras.origin, "home-page-loader");
+  assert.equal(fakeScope.record.extras.requestId, "req-123");
+});

--- a/apps/web/lib/telemetry.ts
+++ b/apps/web/lib/telemetry.ts
@@ -1,0 +1,41 @@
+import * as Sentry from "@sentry/nextjs";
+
+export type TelemetryContext = Record<string, unknown>;
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if (typeof error === "string") {
+    return new Error(error);
+  }
+
+  return new Error("Unknown error");
+}
+
+export function captureWebException(error: unknown, context: TelemetryContext = {}): void {
+  const normalizedError = normalizeError(error);
+
+  Sentry.withScope((scope) => {
+    scope.setTag("surface", "web");
+    Object.entries(context).forEach(([key, value]) => {
+      scope.setExtra(key, value);
+    });
+    scope.setLevel("error");
+    Sentry.captureException(normalizedError);
+  });
+}
+
+export function recordLandingDataLoadFailure(
+  dataset: "catalog" | "featured",
+  error: unknown,
+  extraContext: TelemetryContext = {},
+): void {
+  captureWebException(error, {
+    feature: "landing",
+    dataset,
+    origin: "home-page-loader",
+    ...extraContext,
+  });
+}

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -16,8 +16,12 @@
     "lib/lightning.test.ts",
     "lib/api/comments.ts",
     "lib/api/comments.test.ts",
+    "lib/telemetry.ts",
+    "lib/telemetry.test.ts",
     "components/game-purchase-flow/**/*.ts",
     "components/game-purchase-flow/**/*.tsx",
+    "components/landing/**/*.ts",
+    "components/landing/**/*.tsx",
     "components/ui/**/*.ts",
     "components/ui/**/*.tsx"
   ],

--- a/docs/CROSS_SERVICE_WORKFLOWS.md
+++ b/docs/CROSS_SERVICE_WORKFLOWS.md
@@ -1,0 +1,37 @@
+# Cross-Service Workflows
+
+Bit Indie couples a marketing-forward storefront with a fully instrumented API surface. This reference maps the
+end-to-end responsibilities across the stack so contributors can reason about ripple effects when making changes.
+
+## Lightning Purchase Lifecycle
+
+1. **Storefront surfaces payment context.** The landing checkout screen walks players through the QR invoice,
+   active status timeline, and Lightning address metadata so they understand how sats move during a purchase.
+   Those UI states render the snapshot that higher-level helpers compose for the home page experience.
+   【F:apps/web/components/landing/sections/lightning-checkout-screen.tsx†L1-L79】
+2. **Web clients create and monitor invoices.** The `purchases` API client validates identifiers, issues invoice
+   creation requests, polls for the latest purchase by game/user, and resolves receipts once an invoice settles.
+   These helpers centralize error messages and request policies so the UI can depend on consistent behavior.
+   【F:apps/web/lib/api/purchases.ts†L1-L145】
+3. **Backend workflows reconcile settlement and payouts.** `PurchaseWorkflowService` looks up purchases for
+   authenticated or guest buyers, applies OpenNode webhook updates, provisions download links, and routes sats to
+   the developer and platform treasuries. Whenever a payment posts, it also evaluates promotion heuristics so the
+   catalog reflects fresh momentum automatically.【F:apps/api/src/bit_indie_api/services/purchase_workflow.py†L120-L315】
+
+When evolving Lightning payments, keep the contract between these layers intact: adjust request helpers first,
+refresh the landing snapshots, then update the workflow service so telemetry and payouts remain balanced.
+
+## Moderation and Verified Feedback Loop
+
+1. **UI highlights verified sentiment.** The game detail screen displays the count of verified reviews, flags
+   comments with purchase badges, and offers CTA buttons that depend on checklist progress so community signals are
+   obvious to buyers.【F:apps/web/components/landing/sections/game-detail-screen.tsx†L1-L177】
+2. **Landing helpers aggregate trustworthy metrics.** Featured game summaries supply review and purchase counts
+   that feed the storefront cards, live metrics, and developer checklist, ensuring the marketing layer reflects
+   real transaction data.【F:apps/web/components/landing/landing-helpers.ts†L1-L184】
+3. **API enforces verification rules.** The comment thread service loads first-party remarks, joins author data,
+   and tags responses as verified by cross-checking paid purchases. A shared helper surfaces the set of buyers who
+   actually settled Lightning invoices so moderation decisions rest on canonical data.【F:apps/api/src/bit_indie_api/services/comment_thread/__init__.py†L1-L75】【F:apps/api/src/bit_indie_api/services/comment_thread/verification.py†L1-L27】
+
+Feature work that touches moderation should coordinate changes across these tiers—update helper aggregations, keep
+UI copy aligned with verification guarantees, and evolve backend filters in tandem so badges stay meaningful.


### PR DESCRIPTION
## Summary
- add a codebase health report outlining architectural strengths, testing coverage, and opportunities
- add a landing screen reducer with component-focused tests to exercise the home page state machine
- capture catalog and featured load failures with a shared telemetry helper and document cross-service workflows

## Testing
- npm run test --workspace apps/web

------
https://chatgpt.com/codex/tasks/task_e_68ddfebfa354832bbf3613fca8d23cea