### PR TITLE
feat: add marketing navigation pages and chat support panel

### DIFF
--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+import { ChatSupportPanel } from "../../components/chat/chat-support-panel";
+
+const gradientBackdrop =
+  "absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.2),_transparent_55%)]";
+const gradientAccent =
+  "absolute inset-y-0 right-0 -z-10 w-full max-w-2xl bg-[radial-gradient(circle_at_right,_rgba(56,189,248,0.16),_transparent_60%)]";
+const cardClasses =
+  "relative overflow-hidden rounded-3xl border border-emerald-500/15 bg-slate-950/60 p-6 shadow-[0_0_35px_rgba(16,185,129,0.2)] backdrop-blur-xl before:pointer-events-none before:absolute before:-inset-px before:rounded-[1.45rem] before:border before:border-emerald-500/15 before:opacity-60";
+
+export default function ChatPage(): JSX.Element {
+  return (
+    <main className="relative overflow-hidden bg-slate-950 text-slate-100">
+      <div className={gradientBackdrop} />
+      <div className={gradientAccent} />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-16">
+        <header className="max-w-4xl space-y-4">
+          <p className="text-sm uppercase tracking-[0.35em] text-emerald-200/80">Chat</p>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            Connect with the Bit Indie crew in real time.
+          </h1>
+          <p className="text-base text-slate-300">
+            Need help with a Lightning invoice, download link, or developer workflow? Our live chat team monitors this channel during demo hours.
+          </p>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
+          <ChatSupportPanel />
+          <aside className={cardClasses}>
+            <div className="space-y-4">
+              <h2 className="text-2xl font-semibold text-white">Other ways to reach us</h2>
+              <ul className="space-y-4 text-sm text-slate-300">
+                <li>
+                  <p className="font-semibold text-white">Email</p>
+                  <p>
+                    Drop a note to <a href="mailto:support@bitindie.dev" className="text-emerald-200 hover:text-emerald-100">support@bitindie.dev</a> for anything that isn’t urgent. We reply within 24 hours.
+                  </p>
+                </li>
+                <li>
+                  <p className="font-semibold text-white">Release updates</p>
+                  <p>
+                    We post maintenance windows and Lightning node updates in the home page banner. Ask in chat if you need confirmation on a specific timeframe.
+                  </p>
+                </li>
+                <li>
+                  <p className="font-semibold text-white">Documentation</p>
+                  <p>
+                    Visit the <Link href="/players" className="text-emerald-200 hover:text-emerald-100">player guide</Link> or <Link href="/sell" className="text-emerald-200 hover:text-emerald-100">developer playbook</Link> for self-serve walkthroughs.
+                  </p>
+                </li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -18,17 +18,37 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="bg-slate-950 text-slate-100 antialiased">
         <div className="flex min-h-screen flex-col">
           <header className="border-b border-slate-800 bg-slate-950/70">
-            <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-6 py-4">
-              <div className="space-y-1">
-                <Link
-                  href="/"
-                  className="text-lg font-semibold tracking-tight text-white transition hover:text-emerald-200"
-                >
-                  Bit Indie
-                </Link>
-                <p className="text-sm text-slate-400">Lightning-fast publishing for indie worlds.</p>
+            <div className="mx-auto w-full max-w-6xl px-6 py-4">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div className="space-y-1">
+                  <Link
+                    href="/"
+                    className="text-lg font-semibold tracking-tight text-white transition hover:text-emerald-200"
+                  >
+                    Bit Indie
+                  </Link>
+                  <p className="text-sm text-slate-400">Lightning-fast publishing for indie worlds.</p>
+                </div>
+                <div className="flex flex-col gap-2 lg:items-end">
+                  <nav className="flex flex-wrap items-center gap-3 text-[0.65rem] uppercase tracking-[0.35em] text-slate-300">
+                    <Link className="transition hover:text-emerald-200" href="/games">
+                      Catalog
+                    </Link>
+                    <Link className="transition hover:text-emerald-200" href="/sell">
+                      Sell Your Game
+                    </Link>
+                    <Link className="transition hover:text-emerald-200" href="/players">
+                      Info for Players
+                    </Link>
+                    <Link className="transition hover:text-emerald-200" href="/chat">
+                      Chat
+                    </Link>
+                  </nav>
+                  <span className="text-xs uppercase tracking-[0.35em] text-emerald-200/70 lg:text-right">
+                    Simple MVP preview
+                  </span>
+                </div>
               </div>
-              <span className="text-xs uppercase tracking-[0.35em] text-emerald-200/70">Simple MVP preview</span>
             </div>
           </header>
 

--- a/apps/web/app/players/page.tsx
+++ b/apps/web/app/players/page.tsx
@@ -1,0 +1,120 @@
+import Link from "next/link";
+
+const gradientBackdrop =
+  "absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.16),_transparent_55%)]";
+const gradientAccent =
+  "absolute inset-y-0 left-0 -z-10 w-full max-w-3xl bg-[radial-gradient(circle_at_left,_rgba(59,130,246,0.12),_transparent_60%)]";
+const cardClasses =
+  "relative overflow-hidden rounded-3xl border border-emerald-500/15 bg-slate-950/60 p-6 shadow-[0_0_35px_rgba(16,185,129,0.18)] backdrop-blur-xl before:pointer-events-none before:absolute before:-inset-px before:rounded-[1.45rem] before:border before:border-emerald-500/15 before:opacity-60";
+
+const highlights = [
+  {
+    title: "Lightning-fast checkout",
+    body: "Pay with sats and receive your build instantly. Each invoice tracks status in real time so you can see confirmation within seconds.",
+  },
+  {
+    title: "Verified downloads",
+    body: "Every purchase unlocks a secure download link tied to your account. Revisit your library anytime to grab the latest build.",
+  },
+  {
+    title: "Trusted reviews",
+    body: "Player reviews are tagged when the reviewer has purchased the game, helping you separate real feedback from noise.",
+  },
+];
+
+const faqs = [
+  {
+    question: "How do I start playing?",
+    answer:
+      "Browse the catalog, choose a game, and use the Lightning checkout flow. Your download key appears immediately after the invoice settles.",
+  },
+  {
+    question: "What if my payment fails?",
+    answer:
+      "If a payment expires or fails, the chat crew can regenerate an invoice instantly. No funds are withdrawn until your wallet confirms the payment.",
+  },
+  {
+    question: "Can I gift a game?",
+    answer:
+      "Yes. Purchase the build and forward the secure download link to a friend, or request a gift receipt directly from chat support.",
+  },
+];
+
+export default function PlayersPage(): JSX.Element {
+  return (
+    <main className="relative overflow-hidden bg-slate-950 text-slate-100">
+      <div className={gradientBackdrop} />
+      <div className={gradientAccent} />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-16">
+        <header className="max-w-4xl space-y-4">
+          <p className="text-sm uppercase tracking-[0.35em] text-emerald-200/80">Info for Players</p>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            Discover, purchase, and download Lightning-powered indie worlds.
+          </h1>
+          <p className="text-base text-slate-300">
+            Bit Indie keeps the player journey fast and transparent. Learn how purchases work, what verified reviews mean, and where to go for help.
+          </p>
+        </header>
+
+        <section className="grid gap-6 md:grid-cols-3">
+          {highlights.map((highlight) => (
+            <div className={cardClasses} key={highlight.title}>
+              <div className="space-y-3">
+                <p className="text-xs uppercase tracking-[0.35em] text-emerald-200/70">{highlight.title}</p>
+                <p className="text-sm text-slate-200">{highlight.body}</p>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <section className={cardClasses}>
+          <div className="space-y-6">
+            <h2 className="text-2xl font-semibold text-white">Frequently asked questions</h2>
+            <dl className="space-y-5 text-sm text-slate-300">
+              {faqs.map((faq) => (
+                <div key={faq.question}>
+                  <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200/70">{faq.question}</dt>
+                  <dd className="mt-2 text-sm text-slate-200">{faq.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <div className={cardClasses}>
+            <div className="space-y-4">
+              <h2 className="text-2xl font-semibold text-white">Dive into the catalog</h2>
+              <p className="text-sm text-slate-300">
+                Ready to find your next favorite? Explore featured builds, read verified reviews, and support developers directly with Lightning.
+              </p>
+              <Link
+                href="/games"
+                className="inline-flex items-center justify-center rounded-full border border-emerald-400/70 bg-emerald-500/20 px-5 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-100 shadow-[0_0_24px_rgba(16,185,129,0.3)] transition hover:border-emerald-300 hover:text-emerald-50"
+              >
+                Browse the catalog
+              </Link>
+            </div>
+          </div>
+          <div className={cardClasses}>
+            <div className="space-y-4">
+              <h2 className="text-2xl font-semibold text-white">Need live help?</h2>
+              <p className="text-sm text-slate-300">
+                The Bit Indie crew is available during demo hours. Hop into chat for invoice troubleshooting, download resets, or feedback suggestions.
+              </p>
+              <Link
+                href="/chat"
+                className="inline-flex items-center justify-center rounded-full border border-slate-600/70 bg-slate-900/70 px-5 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-200 transition hover:border-emerald-300 hover:text-emerald-50"
+              >
+                Open chat support
+              </Link>
+              <p className="text-xs text-slate-400">
+                Prefer async? Email <a href="mailto:support@bitindie.dev" className="text-emerald-200 hover:text-emerald-100">support@bitindie.dev</a> and we will follow up within a day.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/sell/page.tsx
+++ b/apps/web/app/sell/page.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link";
+
+const gradientBackdrop =
+  "absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_55%)]";
+const gradientAccent =
+  "absolute inset-y-0 right-0 -z-10 w-full max-w-3xl bg-[radial-gradient(circle_at_right,_rgba(14,116,144,0.18),_transparent_60%)]";
+const cardClasses =
+  "relative overflow-hidden rounded-3xl border border-emerald-500/15 bg-slate-950/60 p-6 shadow-[0_0_35px_rgba(16,185,129,0.2)] backdrop-blur-xl before:pointer-events-none before:absolute before:-inset-px before:rounded-[1.45rem] before:border before:border-emerald-500/15 before:opacity-60";
+
+const setupSteps = [
+  {
+    title: "Upload your Lightning-ready build",
+    description:
+      "Package your executable or HTML bundle, include release notes, and upload through the developer console. We verify file integrity before publish.",
+  },
+  {
+    title: "Set pricing and instant payouts",
+    description:
+      "Choose a Lightning price in sats, connect your preferred wallet address, and preview the checkout flow exactly how players will see it.",
+  },
+  {
+    title: "Showcase screenshots and description",
+    description:
+      "Use our markdown editor to craft your pitch, add gallery media, and highlight the features that make your world stand out.",
+  },
+  {
+    title: "Publish and monitor",
+    description:
+      "Go live in minutes. Track purchases, download counts, and verified reviews in real time from the Bit Indie dashboard.",
+  },
+];
+
+export default function SellPage(): JSX.Element {
+  return (
+    <main className="relative overflow-hidden bg-slate-950 text-slate-100">
+      <div className={gradientBackdrop} />
+      <div className={gradientAccent} />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-16">
+        <header className="max-w-4xl space-y-4">
+          <p className="text-sm uppercase tracking-[0.35em] text-emerald-200/80">Sell Your Game</p>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            Launch your Lightning-ready build in minutes.
+          </h1>
+          <p className="text-base text-slate-300">
+            Bit Indie helps small teams move fast. Prepare your listing with the steps below, then invite playtesters or go live
+            to the full marketplace when you are ready.
+          </p>
+        </header>
+
+        <section className="grid gap-6 md:grid-cols-2">
+          {setupSteps.map((step) => (
+            <div className={cardClasses} key={step.title}>
+              <div className="space-y-3">
+                <p className="text-xs uppercase tracking-[0.35em] text-emerald-200/70">{step.title}</p>
+                <p className="text-sm text-slate-200">{step.description}</p>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          <div className={cardClasses}>
+            <div className="space-y-4">
+              <h2 className="text-2xl font-semibold text-white">What we provide</h2>
+              <ul className="space-y-4 text-sm text-slate-300">
+                <li className="flex gap-3">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" aria-hidden="true" />
+                  <div>
+                    <p className="font-semibold text-white">Instant payouts</p>
+                    <p>Lightning invoices settle directly to your wallet with transparent status updates.</p>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" aria-hidden="true" />
+                  <div>
+                    <p className="font-semibold text-white">Sandbox-friendly tooling</p>
+                    <p>
+                      Publish multiple branches of your build, gate experimental features, and invite trusted playtesters before a
+                      full release.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" aria-hidden="true" />
+                  <div>
+                    <p className="font-semibold text-white">Community signal</p>
+                    <p>
+                      Verified reviews show which players purchased the build. Surface highlights on your catalog tile
+                      automatically.
+                    </p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div className={cardClasses}>
+            <div className="space-y-4">
+              <h2 className="text-2xl font-semibold text-white">Ready to list?</h2>
+              <p className="text-sm text-slate-300">
+                Use the developer console to upload builds, manage pricing, and monitor live metrics as purchases come through the
+                Lightning network.
+              </p>
+              <Link
+                href="/admin"
+                className="inline-flex items-center justify-center rounded-full border border-emerald-400/70 bg-emerald-500/20 px-5 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-100 shadow-[0_0_24px_rgba(16,185,129,0.3)] transition hover:border-emerald-300 hover:text-emerald-50"
+              >
+                Open developer console
+              </Link>
+              <p className="text-xs text-slate-400">
+                Need onboarding help? Jump into our <Link href="/chat" className="text-emerald-200 hover:text-emerald-100">chat support</Link>{" "}
+                or email <a href="mailto:hello@bitindie.dev" className="text-emerald-200 hover:text-emerald-100">hello@bitindie.dev</a>.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/chat/chat-support-panel.tsx
+++ b/apps/web/components/chat/chat-support-panel.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { FormEvent, useEffect, useRef, useState } from "react";
+
+type MessageAuthor = "player" | "support";
+
+type Message = {
+  id: number;
+  author: MessageAuthor;
+  body: string;
+  timestamp: string;
+};
+
+const supportReplies = [
+  "Thanks for reaching out! We keep the queue light during the MVP, so you can expect responses within a minute.",
+  "If you're troubleshooting an invoice, share the payment hash and we can verify it across our Lightning node logs.",
+  "Need a fresh download link? Let me know the game title and we'll regenerate the secure URL for you right away.",
+];
+
+function formatTimestamp(date: Date): string {
+  return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+}
+
+export function ChatSupportPanel(): JSX.Element {
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      id: 1,
+      author: "support",
+      body: "Welcome to Bit Indie support! Ask anything about Lightning checkout, downloads, or your developer console.",
+      timestamp: formatTimestamp(new Date()),
+    },
+  ]);
+  const [inputValue, setInputValue] = useState("");
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const replyIndexRef = useRef(0);
+
+  useEffect(() => {
+    if (!listRef.current) {
+      return;
+    }
+
+    listRef.current.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages]);
+
+  function queueSupportReply(): void {
+    setTimeout(() => {
+      const reply = supportReplies[replyIndexRef.current % supportReplies.length];
+      replyIndexRef.current += 1;
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now() + replyIndexRef.current,
+          author: "support",
+          body: reply,
+          timestamp: formatTimestamp(new Date()),
+        },
+      ]);
+    }, 450);
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+
+    const trimmed = inputValue.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        author: "player",
+        body: trimmed,
+        timestamp: formatTimestamp(new Date()),
+      },
+    ]);
+
+    setInputValue("");
+    queueSupportReply();
+  }
+
+  return (
+    <div className="relative overflow-hidden rounded-3xl border border-emerald-500/15 bg-slate-950/60 p-6 shadow-[0_0_35px_rgba(16,185,129,0.2)] backdrop-blur-xl before:pointer-events-none before:absolute before:-inset-px before:rounded-[1.45rem] before:border before:border-emerald-500/15 before:opacity-60">
+      <div className="relative z-10">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-emerald-200/70">Live chat</p>
+          <h2 className="text-2xl font-semibold text-white">Talk with the Bit Indie crew</h2>
+          <p className="text-sm text-slate-300">
+            Ask about invoices, downloads, or upcoming releases. We monitor this channel during demo windows and respond within a
+            minute.
+          </p>
+        </header>
+
+        <div className="mt-6 h-80 overflow-y-auto pr-2" ref={listRef}>
+          <ul className="flex flex-col gap-4">
+            {messages.map((message) => {
+              const isPlayer = message.author === "player";
+              const alignment = isPlayer ? "items-end" : "items-start";
+              const bubbleClasses = isPlayer
+                ? "bg-emerald-500/20 border-emerald-400/40 text-emerald-50"
+                : "bg-slate-900/70 border-slate-700 text-slate-100";
+
+              return (
+                <li className={`flex ${alignment}`} key={message.id}>
+                  <div className={`max-w-[80%] rounded-2xl border px-4 py-3 shadow-[0_0_22px_rgba(15,118,110,0.25)] ${bubbleClasses}`}>
+                    <p className="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-emerald-200/70">
+                      {isPlayer ? "You" : "Bit Indie"}
+                    </p>
+                    <p className="mt-1 text-sm leading-relaxed text-current">{message.body}</p>
+                    <p className="mt-2 text-[0.6rem] uppercase tracking-[0.35em] text-slate-400">{message.timestamp}</p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <form className="mt-6 flex flex-col gap-3 sm:flex-row" onSubmit={handleSubmit}>
+          <label className="sr-only" htmlFor="chat-input">
+            Ask a question
+          </label>
+          <input
+            id="chat-input"
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            placeholder="Ask about payouts, downloads, or publishing"
+            className="flex-1 rounded-full border border-slate-700 bg-slate-900/60 px-4 py-3 text-sm text-white placeholder:text-slate-500 transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+            autoComplete="off"
+          />
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-full border border-emerald-400/70 bg-emerald-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-100 shadow-[0_0_24px_rgba(16,185,129,0.3)] transition hover:border-emerald-300 hover:text-emerald-50"
+          >
+            Send
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add header navigation with links to catalog, sell, players, and chat screens
- create styled sell and player info pages to guide developers and players
- add chat support page with interactive panel that simulates live assistance

## Testing
- npm run lint:web

------
https://chatgpt.com/codex/tasks/task_e_68de028b4e74832bbbe5b1be88e85eb1