### PR TITLE
Refactor purchase workflow collaborators and admin helpers

### DIFF
--- a/apps/api/src/bit_indie_api/services/purchase_downloads.py
+++ b/apps/api/src/bit_indie_api/services/purchase_downloads.py
@@ -1,0 +1,58 @@
+"""Helpers for generating purchase download links and audit logs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from bit_indie_api.db.models import DownloadAuditLog, InvoiceStatus, Purchase
+from bit_indie_api.services.purchase_errors import (
+    PurchaseBuildUnavailableError,
+    PurchaseNotDownloadableError,
+)
+from bit_indie_api.services.storage import PresignedDownload, StorageService
+
+
+@dataclass(slots=True)
+class PurchaseDownloadManager:
+    """Generate presigned downloads and audit purchase access."""
+
+    session: Session
+    storage: StorageService
+
+    def ensure_downloadable(self, purchase: Purchase) -> None:
+        """Validate that ``purchase`` is eligible for download access."""
+
+        if purchase.invoice_status is not InvoiceStatus.PAID or not purchase.download_granted:
+            raise PurchaseNotDownloadableError()
+
+    def create_download(
+        self,
+        *,
+        purchase: Purchase,
+    ) -> PresignedDownload:
+        """Create a presigned download URL and record an audit entry."""
+
+        game = purchase.game
+        if game is None or not game.build_object_key:
+            raise PurchaseBuildUnavailableError()
+
+        download = self.storage.create_presigned_download(
+            object_key=game.build_object_key
+        )
+
+        audit_log = DownloadAuditLog(
+            purchase_id=purchase.id,
+            user_id=purchase.user_id,
+            game_id=game.id,
+            object_key=game.build_object_key,
+            expires_at=download.expires_at,
+        )
+        self.session.add(audit_log)
+        self.session.flush()
+
+        return download
+
+
+__all__ = ["PurchaseDownloadManager"]

--- a/apps/api/src/bit_indie_api/services/purchase_errors.py
+++ b/apps/api/src/bit_indie_api/services/purchase_errors.py
@@ -1,0 +1,95 @@
+"""Custom exceptions for purchase lifecycle operations."""
+
+from __future__ import annotations
+
+from fastapi import status
+
+
+class PurchaseWorkflowError(RuntimeError):
+    """Base error raised when purchase workflow operations fail validation."""
+
+    def __init__(self, detail: str, *, status_code: int) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+class MissingLookupIdentifierError(PurchaseWorkflowError):
+    """Raised when a purchase lookup omits both user and anon identifiers."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Provide user_id or anon_id to look up purchases.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+class GuestLookupError(PurchaseWorkflowError):
+    """Raised when resolving a guest identifier fails validation."""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail, status_code=status.HTTP_400_BAD_REQUEST)
+
+
+class PurchaseNotFoundError(PurchaseWorkflowError):
+    """Raised when the referenced purchase record cannot be located."""
+
+    def __init__(self) -> None:
+        super().__init__("Purchase not found.", status_code=status.HTTP_404_NOT_FOUND)
+
+
+class PurchasePermissionError(PurchaseWorkflowError):
+    """Raised when a user attempts to act on a purchase they do not own."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "You do not have permission to access this purchase.",
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+
+
+class PurchaseNotDownloadableError(PurchaseWorkflowError):
+    """Raised when a purchase is not yet eligible for download access."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Purchase is not eligible for download.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+class PurchaseBuildUnavailableError(PurchaseWorkflowError):
+    """Raised when the associated game lacks a downloadable build."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Game build is not available for download.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+class PurchaseNotRefundableError(PurchaseWorkflowError):
+    """Raised when a purchase fails the prerequisites for requesting a refund."""
+
+    def __init__(self, detail: str = "Only paid purchases can be refunded.") -> None:
+        super().__init__(detail, status_code=status.HTTP_400_BAD_REQUEST)
+
+
+class PaymentProviderUnavailableError(PurchaseWorkflowError):
+    """Raised when the Lightning provider returns an error response."""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail, status_code=status.HTTP_502_BAD_GATEWAY)
+
+
+__all__ = [
+    "GuestLookupError",
+    "MissingLookupIdentifierError",
+    "PaymentProviderUnavailableError",
+    "PurchaseBuildUnavailableError",
+    "PurchaseNotDownloadableError",
+    "PurchaseNotFoundError",
+    "PurchaseNotRefundableError",
+    "PurchasePermissionError",
+    "PurchaseWorkflowError",
+]

--- a/apps/api/src/bit_indie_api/services/purchase_lookup.py
+++ b/apps/api/src/bit_indie_api/services/purchase_lookup.py
@@ -1,0 +1,75 @@
+"""Lookup helpers for purchase records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from bit_indie_api.db.models import InvoiceStatus, Purchase
+from bit_indie_api.services.guest_checkout import GuestCheckoutError, GuestCheckoutService
+from bit_indie_api.services.purchase_errors import (
+    GuestLookupError,
+    MissingLookupIdentifierError,
+    PurchaseNotFoundError,
+)
+
+
+@dataclass(slots=True)
+class PurchaseLookupService:
+    """Resolve purchases for authenticated or guest buyers."""
+
+    session: Session
+    guest_checkout: GuestCheckoutService
+
+    def lookup_purchase(
+        self,
+        *,
+        game_id: str,
+        user_id: str | None,
+        anon_id: str | None,
+    ) -> Purchase:
+        """Return the newest purchase matching the provided identifiers."""
+
+        lookup_user_id = user_id
+        if lookup_user_id is None:
+            if anon_id is None:
+                raise MissingLookupIdentifierError()
+            try:
+                guest_user = self.guest_checkout.get_guest_user(anon_id=anon_id)
+            except GuestCheckoutError as exc:  # pragma: no cover - defensive guard
+                raise GuestLookupError(str(exc)) from exc
+            if guest_user is None:
+                raise PurchaseNotFoundError()
+            lookup_user_id = guest_user.id
+
+        order_by_columns = (Purchase.created_at.desc(), Purchase.id.desc())
+        completed_stmt = (
+            select(Purchase)
+            .where(
+                Purchase.game_id == game_id,
+                Purchase.user_id == lookup_user_id,
+                or_(
+                    Purchase.download_granted.is_(True),
+                    Purchase.invoice_status == InvoiceStatus.PAID,
+                ),
+            )
+            .order_by(*order_by_columns)
+            .limit(1)
+        )
+        purchase = self.session.scalars(completed_stmt).first()
+        if purchase is None:
+            fallback_stmt = (
+                select(Purchase)
+                .where(Purchase.game_id == game_id, Purchase.user_id == lookup_user_id)
+                .order_by(*order_by_columns)
+                .limit(1)
+            )
+            purchase = self.session.scalars(fallback_stmt).first()
+        if purchase is None:
+            raise PurchaseNotFoundError()
+        return purchase
+
+
+__all__ = ["PurchaseLookupService"]

--- a/apps/api/src/bit_indie_api/services/purchase_payouts.py
+++ b/apps/api/src/bit_indie_api/services/purchase_payouts.py
@@ -1,0 +1,144 @@
+"""Helpers for computing and executing revenue payouts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bit_indie_api.db.models import PayoutStatus, Purchase
+from bit_indie_api.services.payments import PaymentService, PaymentServiceError
+
+
+@dataclass(slots=True, frozen=True)
+class RevenueSplit:
+    """Describe how a purchase's revenue is divided between stakeholders."""
+
+    total_msats: int
+    developer_msats: int
+    platform_msats: int
+
+
+def calculate_revenue_split(amount_msats: int) -> RevenueSplit:
+    """Return a developer/platform split rounded to the nearest thousand msats."""
+
+    total = max(0, amount_msats)
+    if total == 0:
+        return RevenueSplit(total_msats=0, developer_msats=0, platform_msats=0)
+
+    developer_share = (total * 85) // 100
+    platform_share = total - developer_share
+
+    developer_share_rounded = (developer_share // 1000) * 1000
+    developer_remainder = developer_share - developer_share_rounded
+    developer_share = developer_share_rounded
+    platform_share += developer_remainder
+
+    platform_share_rounded = (platform_share // 1000) * 1000
+    platform_remainder = platform_share - platform_share_rounded
+    platform_share = platform_share_rounded
+    developer_share += platform_remainder
+
+    if developer_share == 0 and total >= 1000:
+        developer_share = 1000
+        platform_share = max(0, total - developer_share)
+        platform_share = (platform_share // 1000) * 1000
+        developer_share = total - platform_share
+
+    return RevenueSplit(
+        total_msats=total,
+        developer_msats=developer_share,
+        platform_msats=platform_share,
+    )
+
+
+@dataclass(slots=True)
+class RevenuePayoutManager:
+    """Issue Lightning payouts for completed purchases."""
+
+    payments: PaymentService
+
+    def process_purchase(self, purchase: Purchase) -> RevenueSplit | None:
+        """Send developer and platform payouts for ``purchase`` when applicable."""
+
+        game = purchase.game
+        if game is None:
+            return None
+
+        amount_msats = purchase.amount_msats or 0
+        if amount_msats <= 0:
+            return RevenueSplit(total_msats=0, developer_msats=0, platform_msats=0)
+
+        split = calculate_revenue_split(amount_msats)
+
+        developer_address = game.developer_lightning_address
+        treasury_address = self.payments.treasury_wallet_address
+
+        if purchase.developer_payout_status is not PayoutStatus.COMPLETED:
+            self._execute_payout(
+                purchase=purchase,
+                recipient="developer",
+                address=developer_address,
+                amount_msats=split.developer_msats,
+                status_attr="developer_payout_status",
+                reference_attr="developer_payout_reference",
+                error_attr="developer_payout_error",
+            )
+
+        if purchase.platform_payout_status is not PayoutStatus.COMPLETED:
+            self._execute_payout(
+                purchase=purchase,
+                recipient="platform",
+                address=treasury_address,
+                amount_msats=split.platform_msats,
+                status_attr="platform_payout_status",
+                reference_attr="platform_payout_reference",
+                error_attr="platform_payout_error",
+            )
+
+        return split
+
+    def _execute_payout(
+        self,
+        *,
+        purchase: Purchase,
+        recipient: str,
+        address: str | None,
+        amount_msats: int,
+        status_attr: str,
+        reference_attr: str,
+        error_attr: str,
+    ) -> None:
+        """Issue a payout and persist the resulting status on ``purchase``."""
+
+        status: PayoutStatus
+        reference: str | None = None
+        error_message: str | None = None
+
+        if amount_msats <= 0:
+            status = PayoutStatus.COMPLETED
+        elif not address:
+            status = PayoutStatus.FAILED
+            error_message = f"Missing Lightning address for {recipient} payout."
+        else:
+            try:
+                result = self.payments.send_payout(
+                    amount_msats=amount_msats,
+                    lightning_address=address,
+                    memo=f"Bit Indie purchase {purchase.id} ({recipient})",
+                )
+            except PaymentServiceError as exc:
+                status = PayoutStatus.FAILED
+                error_message = str(exc)
+            else:
+                status = PayoutStatus.COMPLETED
+                reference = result.payout_id
+
+        setattr(purchase, status_attr, status)
+        setattr(purchase, reference_attr, reference)
+        setattr(purchase, error_attr, error_message)
+
+
+__all__ = [
+    "RevenuePayoutManager",
+    "RevenueSplit",
+    "calculate_revenue_split",
+]

--- a/apps/api/src/bit_indie_api/services/purchase_workflow.py
+++ b/apps/api/src/bit_indie_api/services/purchase_workflow.py
@@ -5,24 +5,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from fastapi import Depends, status
-from sqlalchemy import or_, select
+from fastapi import Depends
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from bit_indie_api.db import get_session
-from bit_indie_api.db.models import (
-    DownloadAuditLog,
-    InvoiceStatus,
-    PayoutStatus,
-    Purchase,
-    RefundStatus,
-)
+from bit_indie_api.db.models import InvoiceStatus, Purchase, RefundStatus
 from bit_indie_api.services.game_promotion import (
     maybe_promote_game_to_discover,
     update_game_featured_status,
 )
 from bit_indie_api.services.guest_checkout import (
-    GuestCheckoutError,
     GuestCheckoutService,
     get_guest_checkout_service,
 )
@@ -31,90 +24,25 @@ from bit_indie_api.services.payments import (
     PaymentServiceError,
     get_payment_service,
 )
+from bit_indie_api.services.purchase_downloads import PurchaseDownloadManager
+from bit_indie_api.services.purchase_errors import (
+    GuestLookupError,
+    MissingLookupIdentifierError,
+    PaymentProviderUnavailableError,
+    PurchaseBuildUnavailableError,
+    PurchaseNotDownloadableError,
+    PurchaseNotFoundError,
+    PurchaseNotRefundableError,
+    PurchasePermissionError,
+    PurchaseWorkflowError,
+)
+from bit_indie_api.services.purchase_lookup import PurchaseLookupService
+from bit_indie_api.services.purchase_payouts import RevenuePayoutManager
 from bit_indie_api.services.storage import (
     PresignedDownload,
     StorageService,
     get_storage_service,
 )
-
-
-class PurchaseWorkflowError(RuntimeError):
-    """Base error raised when purchase workflow operations fail validation."""
-
-    def __init__(self, detail: str, *, status_code: int) -> None:
-        super().__init__(detail)
-        self.detail = detail
-        self.status_code = status_code
-
-
-class MissingLookupIdentifierError(PurchaseWorkflowError):
-    """Raised when a purchase lookup omits both user and anon identifiers."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            "Provide user_id or anon_id to look up purchases.",
-            status_code=status.HTTP_400_BAD_REQUEST,
-        )
-
-
-class GuestLookupError(PurchaseWorkflowError):
-    """Raised when resolving a guest identifier fails validation."""
-
-    def __init__(self, detail: str) -> None:
-        super().__init__(detail, status_code=status.HTTP_400_BAD_REQUEST)
-
-
-class PurchaseNotFoundError(PurchaseWorkflowError):
-    """Raised when the referenced purchase record cannot be located."""
-
-    def __init__(self) -> None:
-        super().__init__("Purchase not found.", status_code=status.HTTP_404_NOT_FOUND)
-
-
-class PurchasePermissionError(PurchaseWorkflowError):
-    """Raised when a user attempts to act on a purchase they do not own."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            "You do not have permission to access this purchase.",
-            status_code=status.HTTP_403_FORBIDDEN,
-        )
-
-
-class PurchaseNotDownloadableError(PurchaseWorkflowError):
-    """Raised when a purchase is not yet eligible for download access."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            "Purchase is not eligible for download.",
-            status_code=status.HTTP_400_BAD_REQUEST,
-        )
-
-
-class PurchaseBuildUnavailableError(PurchaseWorkflowError):
-    """Raised when the associated game lacks a downloadable build."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            "Game build is not available for download.",
-            status_code=status.HTTP_400_BAD_REQUEST,
-        )
-
-
-class PurchaseNotRefundableError(PurchaseWorkflowError):
-    """Raised when a purchase fails the prerequisites for requesting a refund."""
-
-    def __init__(self, detail: str = "Only paid purchases can be refunded.") -> None:
-        super().__init__(detail, status_code=status.HTTP_400_BAD_REQUEST)
-
-
-class PaymentProviderUnavailableError(PurchaseWorkflowError):
-    """Raised when the Lightning provider returns an error response."""
-
-    def __init__(self, detail: str) -> None:
-        super().__init__(detail, status_code=status.HTTP_502_BAD_GATEWAY)
-
-
 @dataclass(slots=True)
 class PurchaseDownloadResult:
     """Value object describing a generated download link for a purchase."""
@@ -128,9 +56,10 @@ class PurchaseWorkflowService:
     """Encapsulate purchase lifecycle transitions and lookups."""
 
     session: Session
-    guest_checkout: GuestCheckoutService
     payments: PaymentService
-    storage: StorageService
+    lookup: PurchaseLookupService
+    payouts: RevenuePayoutManager
+    downloads: PurchaseDownloadManager
 
     def lookup_purchase(
         self,
@@ -141,44 +70,9 @@ class PurchaseWorkflowService:
     ) -> Purchase:
         """Return the newest purchase matching the provided identifiers."""
 
-        lookup_user_id = user_id
-        if lookup_user_id is None:
-            if anon_id is None:
-                raise MissingLookupIdentifierError()
-            try:
-                guest_user = self.guest_checkout.get_guest_user(anon_id=anon_id)
-            except GuestCheckoutError as exc:
-                raise GuestLookupError(str(exc)) from exc
-            if guest_user is None:
-                raise PurchaseNotFoundError()
-            lookup_user_id = guest_user.id
-
-        order_by_columns = (Purchase.created_at.desc(), Purchase.id.desc())
-        completed_stmt = (
-            select(Purchase)
-            .where(
-                Purchase.game_id == game_id,
-                Purchase.user_id == lookup_user_id,
-                or_(
-                    Purchase.download_granted.is_(True),
-                    Purchase.invoice_status == InvoiceStatus.PAID,
-                ),
-            )
-            .order_by(*order_by_columns)
-            .limit(1)
+        return self.lookup.lookup_purchase(
+            game_id=game_id, user_id=user_id, anon_id=anon_id
         )
-        purchase = self.session.scalars(completed_stmt).first()
-        if purchase is None:
-            fallback_stmt = (
-                select(Purchase)
-                .where(Purchase.game_id == game_id, Purchase.user_id == lookup_user_id)
-                .order_by(*order_by_columns)
-                .limit(1)
-            )
-            purchase = self.session.scalars(fallback_stmt).first()
-        if purchase is None:
-            raise PurchaseNotFoundError()
-        return purchase
 
     def reconcile_opennode_webhook(self, *, invoice_id: str) -> bool:
         """Update purchase state using the latest OpenNode invoice information."""
@@ -201,7 +95,7 @@ class PurchaseWorkflowService:
                 purchase.paid_at = datetime.now(timezone.utc)
             if status_info.amount_msats is not None:
                 purchase.amount_msats = status_info.amount_msats
-            self._process_revenue_payouts(purchase=purchase)
+            self.payouts.process_purchase(purchase=purchase)
         elif not status_info.pending and purchase.invoice_status is InvoiceStatus.PENDING:
             purchase.invoice_status = InvoiceStatus.EXPIRED
 
@@ -234,123 +128,10 @@ class PurchaseWorkflowService:
         if purchase.user_id != user_id:
             raise PurchasePermissionError()
 
-        if purchase.invoice_status is not InvoiceStatus.PAID or not purchase.download_granted:
-            raise PurchaseNotDownloadableError()
-
-        game = purchase.game
-        if game is None or not game.build_object_key:
-            raise PurchaseBuildUnavailableError()
-
-        download = self.storage.create_presigned_download(
-            object_key=game.build_object_key
-        )
-
-        audit_log = DownloadAuditLog(
-            purchase_id=purchase.id,
-            user_id=purchase.user_id,
-            game_id=game.id,
-            object_key=game.build_object_key,
-            expires_at=download.expires_at,
-        )
-        self.session.add(audit_log)
-        self.session.flush()
+        self.downloads.ensure_downloadable(purchase)
+        download = self.downloads.create_download(purchase=purchase)
 
         return PurchaseDownloadResult(purchase=purchase, download=download)
-
-    def _process_revenue_payouts(self, *, purchase: Purchase) -> None:
-        """Trigger revenue payouts to the developer and platform owners."""
-
-        game = purchase.game
-        if game is None:
-            return
-
-        amount_msats = purchase.amount_msats or 0
-        if amount_msats <= 0:
-            return
-
-        developer_share = (amount_msats * 85) // 100
-        platform_share = amount_msats - developer_share
-
-        developer_share_rounded = (developer_share // 1000) * 1000
-        developer_remainder = developer_share - developer_share_rounded
-        developer_share = developer_share_rounded
-        platform_share += developer_remainder
-
-        platform_share_rounded = (platform_share // 1000) * 1000
-        platform_remainder = platform_share - platform_share_rounded
-        platform_share = platform_share_rounded
-        developer_share += platform_remainder
-
-        if developer_share == 0 and amount_msats >= 1000:
-            developer_share = 1000
-            platform_share = max(0, amount_msats - developer_share)
-            platform_share = (platform_share // 1000) * 1000
-            developer_share = amount_msats - platform_share
-
-        developer_address = game.developer_lightning_address
-        treasury_address = self.payments.treasury_wallet_address
-
-        if purchase.developer_payout_status is not PayoutStatus.COMPLETED:
-            self._execute_payout(
-                purchase=purchase,
-                recipient="developer",
-                address=developer_address,
-                amount_msats=developer_share,
-                status_attr="developer_payout_status",
-                reference_attr="developer_payout_reference",
-                error_attr="developer_payout_error",
-            )
-
-        if purchase.platform_payout_status is not PayoutStatus.COMPLETED:
-            self._execute_payout(
-                purchase=purchase,
-                recipient="platform",
-                address=treasury_address,
-                amount_msats=platform_share,
-                status_attr="platform_payout_status",
-                reference_attr="platform_payout_reference",
-                error_attr="platform_payout_error",
-            )
-
-    def _execute_payout(
-        self,
-        *,
-        purchase: Purchase,
-        recipient: str,
-        address: str | None,
-        amount_msats: int,
-        status_attr: str,
-        reference_attr: str,
-        error_attr: str,
-    ) -> None:
-        """Issue a payout through the payment provider and persist the outcome."""
-
-        status: PayoutStatus
-        reference: str | None = None
-        error_message: str | None = None
-
-        if amount_msats <= 0:
-            status = PayoutStatus.COMPLETED
-        elif not address:
-            status = PayoutStatus.FAILED
-            error_message = f"Missing Lightning address for {recipient} payout."
-        else:
-            try:
-                result = self.payments.send_payout(
-                    amount_msats=amount_msats,
-                    lightning_address=address,
-                    memo=f"Bit Indie purchase {purchase.id} ({recipient})",
-                )
-            except PaymentServiceError as exc:
-                status = PayoutStatus.FAILED
-                error_message = str(exc)
-            else:
-                status = PayoutStatus.COMPLETED
-                reference = result.payout_id
-
-        setattr(purchase, status_attr, status)
-        setattr(purchase, reference_attr, reference)
-        setattr(purchase, error_attr, error_message)
 
     def request_refund(self, *, purchase_id: str, user_id: str) -> Purchase:
         """Flag a paid purchase for refund review."""
@@ -387,9 +168,10 @@ def get_purchase_workflow_service(
 
     return PurchaseWorkflowService(
         session=session,
-        guest_checkout=guest_checkout,
         payments=payments,
-        storage=storage,
+        lookup=PurchaseLookupService(session=session, guest_checkout=guest_checkout),
+        payouts=RevenuePayoutManager(payments=payments),
+        downloads=PurchaseDownloadManager(session=session, storage=storage),
     )
 
 

--- a/apps/api/tests/test_services_purchase_downloads.py
+++ b/apps/api/tests/test_services_purchase_downloads.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+
+from sqlalchemy import select
+
+from bit_indie_api.db import Base, get_engine, reset_database_state, session_scope
+from bit_indie_api.db.models import DownloadAuditLog, Game, InvoiceStatus, Purchase, User
+from bit_indie_api.services.purchase_downloads import PurchaseDownloadManager
+from bit_indie_api.services.purchase_errors import (
+    PurchaseBuildUnavailableError,
+    PurchaseNotDownloadableError,
+)
+from bit_indie_api.services.storage import PresignedDownload
+
+
+class _StubStorage:
+    """Test double that records download requests."""
+
+    def __init__(self) -> None:
+        self.object_keys: list[str] = []
+        self.response = PresignedDownload(
+            url="https://example.com/build.zip",
+            expires_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+        )
+
+    def create_presigned_download(self, *, object_key: str) -> PresignedDownload:
+        self.object_keys.append(object_key)
+        return self.response
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run each test against an isolated in-memory database."""
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    reset_database_state()
+    yield
+    reset_database_state()
+
+
+def _create_schema() -> None:
+    """Create the ORM schema for the temporary SQLite database."""
+
+    engine = get_engine()
+    Base.metadata.create_all(engine)
+
+
+def _create_game_with_purchase(session) -> Purchase:
+    """Persist a user, game, and paid purchase for download tests."""
+
+    user = User(account_identifier="download-user")
+    session.add(user)
+    session.flush()
+
+    game = Game(
+        developer_id=user.id,
+        title="Downloadable",
+        slug="downloadable",
+        price_msats=5_000,
+        build_object_key="games/downloadable.zip",
+    )
+    session.add(game)
+    session.flush()
+
+    purchase = Purchase(
+        user_id=user.id,
+        game_id=game.id,
+        invoice_id=f"inv-{uuid.uuid4().hex}",
+        invoice_status=InvoiceStatus.PAID,
+        download_granted=True,
+    )
+    session.add(purchase)
+    session.flush()
+    return purchase
+
+
+def test_ensure_downloadable_rejects_unpaid_purchase() -> None:
+    """The download manager should guard against unpaid purchases."""
+
+    _create_schema()
+    with session_scope() as session:
+        purchase = _create_game_with_purchase(session)
+        purchase.invoice_status = InvoiceStatus.PENDING
+        purchase.download_granted = False
+
+        manager = PurchaseDownloadManager(session=session, storage=_StubStorage())
+
+        with pytest.raises(PurchaseNotDownloadableError):
+            manager.ensure_downloadable(purchase)
+
+
+def test_create_download_logs_access() -> None:
+    """Creating a download should hit storage and persist an audit row."""
+
+    _create_schema()
+    with session_scope() as session:
+        purchase = _create_game_with_purchase(session)
+        manager = PurchaseDownloadManager(session=session, storage=_StubStorage())
+
+        manager.ensure_downloadable(purchase)
+        download = manager.create_download(purchase=purchase)
+
+        assert download.url.endswith("build.zip")
+        audit = session.scalars(
+            select(DownloadAuditLog).where(DownloadAuditLog.purchase_id == purchase.id)
+        ).one()
+        assert audit.object_key == "games/downloadable.zip"
+        assert audit.expires_at == download.expires_at.replace(tzinfo=None)
+
+
+def test_create_download_requires_build_object() -> None:
+    """An audit entry cannot be created when the game lacks a build."""
+
+    _create_schema()
+    with session_scope() as session:
+        purchase = _create_game_with_purchase(session)
+        purchase.game.build_object_key = None
+
+        manager = PurchaseDownloadManager(session=session, storage=_StubStorage())
+        manager.ensure_downloadable(purchase)
+
+        with pytest.raises(PurchaseBuildUnavailableError):
+            manager.create_download(purchase=purchase)

--- a/apps/api/tests/test_services_purchase_payouts.py
+++ b/apps/api/tests/test_services_purchase_payouts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from bit_indie_api.services.purchase_payouts import calculate_revenue_split
+
+
+@pytest.mark.parametrize(
+    "amount_msats, expected_developer, expected_platform",
+    [
+        (100_000, 85_000, 15_000),
+        (1_234_567, 1_049_567, 185_000),
+        (1_000, 1_000, 0),
+        (999, 999, 0),
+    ],
+)
+def test_calculate_revenue_split_rounds_and_balances(
+    amount_msats: int, expected_developer: int, expected_platform: int
+) -> None:
+    """Rounding and balancing should mirror production payout rules."""
+
+    split = calculate_revenue_split(amount_msats)
+
+    assert split.developer_msats == expected_developer
+    assert split.platform_msats == expected_platform
+    assert split.developer_msats + split.platform_msats == split.total_msats
+    developer_remainder = split.developer_msats % 1000
+    platform_remainder = split.platform_msats % 1000
+    assert developer_remainder == 0 or platform_remainder == 0
+    assert developer_remainder + platform_remainder == split.total_msats % 1000
+
+
+def test_calculate_revenue_split_handles_negative_values() -> None:
+    """Negative purchase totals should be clamped to zero before splitting."""
+
+    split = calculate_revenue_split(-5_000)
+
+    assert split.total_msats == 0
+    assert split.developer_msats == 0
+    assert split.platform_msats == 0

--- a/apps/web/components/game-draft-form/form-utils.test.ts
+++ b/apps/web/components/game-draft-form/form-utils.test.ts
@@ -7,9 +7,6 @@ import {
   buildUpdatePayload,
   createInitialValues,
   mapDraftToValues,
-  normalizeChecksum,
-  normalizeOrNull,
-  parseOptionalNonNegativeInteger,
 } from "./form-utils";
 
 test("createInitialValues returns empty defaults", () => {
@@ -27,22 +24,6 @@ test("createInitialValues returns empty defaults", () => {
     build_size_bytes: "",
     checksum_sha256: "",
   });
-});
-
-test("normalizeOrNull trims whitespace and returns null when empty", () => {
-  assert.equal(normalizeOrNull("   hello  "), "hello");
-  assert.equal(normalizeOrNull("   "), null);
-});
-
-test("parseOptionalNonNegativeInteger converts values when valid", () => {
-  assert.equal(parseOptionalNonNegativeInteger(" 42 ", "Field"), 42);
-  assert.equal(parseOptionalNonNegativeInteger("", "Field"), null);
-  assert.throws(() => parseOptionalNonNegativeInteger("-5", "Field"));
-});
-
-test("normalizeChecksum lowercases non-empty strings", () => {
-  assert.equal(normalizeChecksum(" ABC123 "), "abc123");
-  assert.equal(normalizeChecksum("   "), null);
 });
 
 test("buildCreatePayload normalizes strings and numeric inputs", () => {

--- a/apps/web/components/game-draft-form/form-utils.ts
+++ b/apps/web/components/game-draft-form/form-utils.ts
@@ -1,4 +1,14 @@
-import { type GameCategory, type GameDraft, type CreateGameDraftRequest, type UpdateGameDraftRequest } from "../../lib/api";
+import {
+  type GameCategory,
+  type GameDraft,
+  type CreateGameDraftRequest,
+  type UpdateGameDraftRequest,
+} from "../../lib/api";
+import {
+  normalizeToLowercaseOrNull,
+  parseOptionalInteger,
+  trimToNull,
+} from "../../lib/forms/normalizers";
 
 export type GameDraftFormValues = {
   title: string;
@@ -30,39 +40,16 @@ export function createInitialValues(): GameDraftFormValues {
   };
 }
 
-export function normalizeOrNull(value: string): string | null {
-  const trimmed = value.trim();
-  return trimmed === "" ? null : trimmed;
-}
-
-export function parseOptionalNonNegativeInteger(value: string, fieldName: string): number | null {
-  const trimmed = value.trim();
-  if (trimmed === "") {
-    return null;
-  }
-
-  const numeric = Number(trimmed);
-  if (!Number.isFinite(numeric) || numeric < 0) {
-    throw new Error(`${fieldName} must be a non-negative number.`);
-  }
-  return Math.trunc(numeric);
-}
-
-export function normalizeChecksum(value: string): string | null {
-  const trimmed = value.trim();
-  return trimmed === "" ? null : trimmed.toLowerCase();
-}
-
 export function buildCreatePayload(values: GameDraftFormValues, userId: string): CreateGameDraftRequest {
   return {
     user_id: userId,
     title: values.title.trim(),
     slug: values.slug.trim(),
-    summary: normalizeOrNull(values.summary),
-    description_md: normalizeOrNull(values.description_md),
-    price_msats: parseOptionalNonNegativeInteger(values.price_msats, "Price"),
-    cover_url: normalizeOrNull(values.cover_url),
-    trailer_url: normalizeOrNull(values.trailer_url),
+    summary: trimToNull(values.summary),
+    description_md: trimToNull(values.description_md),
+    price_msats: parseOptionalInteger(values.price_msats, "Price", { min: 0 }),
+    cover_url: trimToNull(values.cover_url),
+    trailer_url: trimToNull(values.trailer_url),
     category: values.category,
   };
 }
@@ -70,9 +57,9 @@ export function buildCreatePayload(values: GameDraftFormValues, userId: string):
 export function buildUpdatePayload(values: GameDraftFormValues, userId: string): UpdateGameDraftRequest {
   return {
     ...buildCreatePayload(values, userId),
-    build_object_key: normalizeOrNull(values.build_object_key),
-    build_size_bytes: parseOptionalNonNegativeInteger(values.build_size_bytes, "Build size"),
-    checksum_sha256: normalizeChecksum(values.checksum_sha256),
+    build_object_key: trimToNull(values.build_object_key),
+    build_size_bytes: parseOptionalInteger(values.build_size_bytes, "Build size", { min: 0 }),
+    checksum_sha256: normalizeToLowercaseOrNull(values.checksum_sha256),
   };
 }
 

--- a/apps/web/lib/format/admin-integrity.test.ts
+++ b/apps/web/lib/format/admin-integrity.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatIntegrityCount,
+  formatIntegrityHours,
+  formatIntegrityMsats,
+  formatIntegrityPercentage,
+} from "./admin-integrity";
+
+test("formatIntegrityPercentage clamps inputs", () => {
+  assert.equal(formatIntegrityPercentage(0.42), "42.0%");
+  assert.equal(formatIntegrityPercentage(-1), "0%");
+  assert.equal(formatIntegrityPercentage(5), "100.0%");
+});
+
+test("formatIntegrityHours includes a single decimal", () => {
+  assert.equal(formatIntegrityHours(12.345), "12.3");
+  assert.equal(formatIntegrityHours(Number.NaN), "0");
+});
+
+test("formatIntegrityMsats renders msats and sats", () => {
+  assert.equal(formatIntegrityMsats(123_000), "123,000 msats (123 sats)");
+  assert.equal(formatIntegrityMsats(500), "500 msats (0.50 sats)");
+});
+
+test("formatIntegrityCount formats with separators", () => {
+  assert.equal(formatIntegrityCount(1234567), "1,234,567");
+});

--- a/apps/web/lib/format/admin-integrity.ts
+++ b/apps/web/lib/format/admin-integrity.ts
@@ -1,0 +1,38 @@
+/** Format a ratio (0-1) into a percentage string. */
+export function formatIntegrityPercentage(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "0%";
+  }
+  const clamped = Math.max(0, Math.min(value, 1));
+  return `${(clamped * 100).toFixed(1)}%`;
+}
+
+/** Format a number of hours with a single decimal place. */
+export function formatIntegrityHours(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+}
+
+/**
+ * Format milli-satoshis alongside their satoshi equivalent.
+ */
+export function formatIntegrityMsats(value: number): string {
+  const msats = Math.max(0, value);
+  const sats = msats / 1000;
+  const formattedMsats = msats.toLocaleString("en-US");
+  const formattedSats = sats.toLocaleString("en-US", {
+    minimumFractionDigits: sats > 0 && sats < 1 ? 2 : 0,
+    maximumFractionDigits: 2,
+  });
+  return `${formattedMsats} msats (${formattedSats} sats)`;
+}
+
+/** Format counts with standard thousands separators. */
+export function formatIntegrityCount(value: number): string {
+  return Math.max(0, value).toLocaleString("en-US");
+}

--- a/apps/web/lib/forms/normalizers.test.ts
+++ b/apps/web/lib/forms/normalizers.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeToLowercaseOrNull,
+  parseOptionalInteger,
+  trimToNull,
+} from "./normalizers";
+
+test("trimToNull trims and nullifies blank strings", () => {
+  assert.equal(trimToNull("  hello "), "hello");
+  assert.equal(trimToNull("   "), null);
+});
+
+test("parseOptionalInteger respects numeric bounds", () => {
+  assert.equal(parseOptionalInteger(" 42 ", "Field", { min: 0 }), 42);
+  assert.equal(parseOptionalInteger("", "Field", { min: 0 }), null);
+  assert.throws(() => parseOptionalInteger("-5", "Field", { min: 0 }));
+  assert.throws(() => parseOptionalInteger("100", "Field", { max: 50 }));
+});
+
+test("normalizeToLowercaseOrNull lowercases non-empty values", () => {
+  assert.equal(normalizeToLowercaseOrNull(" ABC123 "), "abc123");
+  assert.equal(normalizeToLowercaseOrNull("   "), null);
+});

--- a/apps/web/lib/forms/normalizers.ts
+++ b/apps/web/lib/forms/normalizers.ts
@@ -1,0 +1,49 @@
+export type IntegerBounds = {
+  min?: number;
+  max?: number;
+};
+
+/**
+ * Normalize user-supplied text by trimming whitespace and converting blanks to null.
+ */
+export function trimToNull(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Parse an optional integer and clamp it against optional bounds.
+ */
+export function parseOptionalInteger(
+  value: string,
+  fieldName: string,
+  bounds: IntegerBounds = {},
+): number | null {
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return null;
+  }
+
+  const numeric = Number(trimmed);
+  if (!Number.isFinite(numeric)) {
+    throw new Error(`${fieldName} must be a valid number.`);
+  }
+
+  const integer = Math.trunc(numeric);
+  if (bounds.min != null && integer < bounds.min) {
+    throw new Error(`${fieldName} must be at least ${bounds.min}.`);
+  }
+  if (bounds.max != null && integer > bounds.max) {
+    throw new Error(`${fieldName} must be at most ${bounds.max}.`);
+  }
+
+  return integer;
+}
+
+/**
+ * Normalize optional checksum/hash inputs to lowercase.
+ */
+export function normalizeToLowercaseOrNull(value: string): string | null {
+  const trimmed = trimToNull(value);
+  return trimmed ? trimmed.toLowerCase() : null;
+}

--- a/apps/web/lib/hooks/use-admin-integrity-metrics.ts
+++ b/apps/web/lib/hooks/use-admin-integrity-metrics.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  type AdminIntegrityStats,
+  type UserProfile,
+  getAdminIntegrityStats,
+} from "../api";
+import {
+  USER_PROFILE_STORAGE_EVENT,
+  loadStoredUserProfile,
+} from "../user-storage";
+
+export type AdminIntegrityLoadState = "idle" | "loading" | "success" | "error";
+
+export type AdminIntegrityMetricsState = {
+  profile: UserProfile | null;
+  stats: AdminIntegrityStats | null;
+  loadState: AdminIntegrityLoadState;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+/**
+ * Hook that manages profile changes and fetches admin integrity metrics on demand.
+ */
+export function useAdminIntegrityMetrics(): AdminIntegrityMetricsState {
+  const [profile, setProfile] = useState<UserProfile | null>(() => loadStoredUserProfile());
+  const [stats, setStats] = useState<AdminIntegrityStats | null>(null);
+  const [loadState, setLoadState] = useState<AdminIntegrityLoadState>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    function handleProfileChange(): void {
+      setProfile(loadStoredUserProfile());
+    }
+
+    window.addEventListener(USER_PROFILE_STORAGE_EVENT, handleProfileChange);
+    return () => window.removeEventListener(USER_PROFILE_STORAGE_EVENT, handleProfileChange);
+  }, []);
+
+  useEffect(() => {
+    if (!profile || !profile.is_admin) {
+      setStats(null);
+      setLoadState("idle");
+      setError(null);
+    }
+  }, [profile]);
+
+  const refresh = useCallback(async () => {
+    if (!profile || !profile.is_admin) {
+      return;
+    }
+
+    setLoadState("loading");
+    setError(null);
+    try {
+      const payload = await getAdminIntegrityStats(profile.id);
+      setStats(payload);
+      setLoadState("success");
+    } catch (cause) {
+      setLoadState("error");
+      if (cause instanceof Error) {
+        setError(cause.message);
+      } else {
+        setError("Unable to load integrity metrics.");
+      }
+    }
+  }, [profile]);
+
+  useEffect(() => {
+    if (profile && profile.is_admin) {
+      void refresh();
+    }
+  }, [profile, refresh]);
+
+  return {
+    profile,
+    stats,
+    loadState,
+    error,
+    refresh,
+  };
+}


### PR DESCRIPTION
## Summary
- split the purchase workflow into lookup, download, and payout collaborators while centralizing shared errors
- add focused tests covering the payout math utility and download auditing helper
- extract admin integrity formatting plus state hooks and generalize draft form normalizers for reuse

## Testing
- PYTHONPATH=apps/api/src pytest apps/api/tests/test_services_purchase_workflow.py apps/api/tests/test_services_purchase_downloads.py apps/api/tests/test_services_purchase_payouts.py
- npm run test --workspace apps/web

------
https://chatgpt.com/codex/tasks/task_e_68de0f197e80832bb7dff8e60f564d1f