### PR TITLE
Refactor purchase flow hook into focused helpers

### DIFF
--- a/apps/web/components/game-purchase-flow/invoice-panel.tsx
+++ b/apps/web/components/game-purchase-flow/invoice-panel.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 
 import type { InvoiceCreateResponse } from "../../lib/api";
-import type { CopyState, InvoiceFlowState } from "./hooks";
+import type { CopyState, InvoiceFlowState } from "./types";
 import { ReceiptActions } from "./receipt-actions";
 
 type InvoicePanelProps = {

--- a/apps/web/components/game-purchase-flow/purchase-polling.ts
+++ b/apps/web/components/game-purchase-flow/purchase-polling.ts
@@ -1,5 +1,5 @@
 import { type PurchaseRecord } from "../../lib/api";
-import { type InvoiceFlowState } from "./hooks";
+import { type InvoiceFlowState } from "./types";
 
 export type PurchasePollingHandlers = {
   handlePurchaseUpdate(latest: PurchaseRecord): void;

--- a/apps/web/components/game-purchase-flow/types.ts
+++ b/apps/web/components/game-purchase-flow/types.ts
@@ -1,0 +1,9 @@
+export type InvoiceFlowState =
+  | "idle"
+  | "creating"
+  | "polling"
+  | "paid"
+  | "expired"
+  | "error";
+
+export type CopyState = "idle" | "copied" | "error";

--- a/apps/web/components/game-purchase-flow/use-clipboard-copy.ts
+++ b/apps/web/components/game-purchase-flow/use-clipboard-copy.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { CopyState } from "./types";
+
+type UseClipboardCopyOptions = {
+  text: string | null | undefined;
+  onError?: (error: unknown) => void;
+};
+
+export function useClipboardCopy({ text, onError }: UseClipboardCopyOptions) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+
+  useEffect(() => {
+    setCopyState("idle");
+  }, [text]);
+
+  useEffect(() => {
+    if (copyState !== "copied") {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setCopyState("idle");
+    }, 3000);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [copyState]);
+
+  const handleCopy = useCallback(async () => {
+    if (!text) {
+      return;
+    }
+
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      setCopyState("error");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyState("copied");
+    } catch (error) {
+      setCopyState("error");
+      onError?.(error);
+    }
+  }, [onError, text]);
+
+  return { copyState, handleCopy } as const;
+}

--- a/apps/web/components/game-purchase-flow/use-qr-code.ts
+++ b/apps/web/components/game-purchase-flow/use-qr-code.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+import { buildQrCodeUrl } from "../../lib/qr-code";
+
+export function useLightningQrCode(paymentRequest: string | null | undefined) {
+  const [qrCodeUrl, setQrCodeUrl] = useState<string | null>(null);
+  const [qrGenerationFailed, setQrGenerationFailed] = useState(false);
+
+  useEffect(() => {
+    if (!paymentRequest) {
+      setQrCodeUrl(null);
+      setQrGenerationFailed(false);
+      return undefined;
+    }
+
+    setQrCodeUrl(null);
+    setQrGenerationFailed(false);
+
+    try {
+      const url = buildQrCodeUrl(paymentRequest);
+      setQrCodeUrl(url);
+    } catch (error) {
+      console.error("Failed to generate Lightning invoice QR code.", error);
+      setQrGenerationFailed(true);
+    }
+
+    return undefined;
+  }, [paymentRequest]);
+
+  return { qrCodeUrl, qrGenerationFailed } as const;
+}

--- a/apps/web/components/game-purchase-flow/use-receipt-links.ts
+++ b/apps/web/components/game-purchase-flow/use-receipt-links.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+
+import type { InvoiceCreateResponse } from "../../lib/api";
+
+type UseReceiptLinksOptions = {
+  invoice: InvoiceCreateResponse | null;
+  isGuestCheckout: boolean;
+};
+
+export function useReceiptLinks({ invoice, isGuestCheckout }: UseReceiptLinksOptions) {
+  const receiptUrl = useMemo(() => {
+    if (!invoice || isGuestCheckout) {
+      return null;
+    }
+
+    return `/purchases/${invoice.purchase_id}/receipt`;
+  }, [invoice, isGuestCheckout]);
+
+  const receiptLinkToCopy = useMemo(() => {
+    if (!invoice) {
+      return "";
+    }
+
+    if (!isGuestCheckout) {
+      if (receiptUrl) {
+        if (typeof window !== "undefined") {
+          try {
+            return new URL(receiptUrl, window.location.origin).toString();
+          } catch (error) {
+            console.error("Failed to build receipt link", error);
+          }
+        }
+
+        return receiptUrl;
+      }
+
+      if (invoice.check_url) {
+        return invoice.check_url;
+      }
+
+      return "";
+    }
+
+    return invoice.payment_request;
+  }, [invoice, isGuestCheckout, receiptUrl]);
+
+  return { receiptUrl, receiptLinkToCopy } as const;
+}

--- a/apps/web/components/game-purchase-flow/use-restored-purchase.ts
+++ b/apps/web/components/game-purchase-flow/use-restored-purchase.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+
+import { getLatestPurchaseForGame, type InvoiceCreateResponse, type PurchaseRecord } from "../../lib/api";
+
+type UseRestoredPurchaseOptions = {
+  gameId: string;
+  invoice: InvoiceCreateResponse | null;
+  isPurchasable: boolean;
+  userId: string | null;
+  onDownloadUnlocked: () => void;
+};
+
+export function useRestoredPurchase({
+  gameId,
+  invoice,
+  isPurchasable,
+  userId,
+  onDownloadUnlocked,
+}: UseRestoredPurchaseOptions) {
+  const [purchase, setPurchase] = useState<PurchaseRecord | null>(null);
+
+  useEffect(() => {
+    if (!isPurchasable || !userId || purchase || invoice) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const restorePurchase = async () => {
+      try {
+        const existing = await getLatestPurchaseForGame(gameId, userId);
+        if (cancelled || !existing) {
+          return;
+        }
+
+        setPurchase(existing);
+        if (existing.download_granted) {
+          onDownloadUnlocked();
+        }
+      } catch (_error) {
+        if (cancelled) {
+          return;
+        }
+        // Ignore lookup errors and allow the normal purchase flow to proceed.
+      }
+    };
+
+    void restorePurchase();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [gameId, invoice, isPurchasable, onDownloadUnlocked, purchase, userId]);
+
+  return { purchase, setPurchase } as const;
+}


### PR DESCRIPTION
## Summary
- split useGamePurchaseFlow into smaller hooks for restoring purchases, QR code generation, receipt link building, and clipboard handling
- centralize shared purchase flow types so dependent modules avoid circular imports
- update invoice panel and polling utilities to use the new shared helpers

## Testing
- yarn lint *(fails: workspace package missing in lockfile on runner)*

------
https://chatgpt.com/codex/tasks/task_e_68de8a4c3cbc832bb908e95eef5d4493