### PR TITLE
Refactor purchase flow helpers for Lightning checkout

### DIFF
--- a/apps/web/components/game-purchase-flow/purchase-lookup.ts
+++ b/apps/web/components/game-purchase-flow/purchase-lookup.ts
@@ -1,0 +1,33 @@
+import { getLatestPurchaseForGame, type PurchaseRecord } from "../../lib/api";
+
+type PurchaseLookupOptions = {
+  gameId: string;
+  userId: string;
+  signal?: AbortSignal;
+};
+
+type PurchaseLookupResult = {
+  purchase: PurchaseRecord;
+  downloadUnlocked: boolean;
+};
+
+export async function lookupLatestPurchaseForUser({
+  gameId,
+  userId,
+  signal,
+}: PurchaseLookupOptions): Promise<PurchaseLookupResult | null> {
+  try {
+    const latest = await getLatestPurchaseForGame(gameId, userId);
+    if (signal?.aborted || !latest) {
+      return null;
+    }
+
+    const downloadUnlocked = latest.download_granted === true || latest.invoice_status === "PAID";
+    return { purchase: latest, downloadUnlocked };
+  } catch (_error) {
+    if (signal?.aborted) {
+      return null;
+    }
+    return null;
+  }
+}

--- a/apps/web/components/game-purchase-flow/use-receipt-download.ts
+++ b/apps/web/components/game-purchase-flow/use-receipt-download.ts
@@ -1,0 +1,62 @@
+import { useCallback } from "react";
+
+import { type InvoiceCreateResponse } from "../../lib/api";
+import { buildReceiptDownloadLines } from "./receipt-handling";
+
+type UseReceiptDownloadOptions = {
+  developerLightningAddress: string | null;
+  gameTitle: string;
+  invoice: InvoiceCreateResponse | null;
+  isGuestCheckout: boolean;
+  priceLabel: string;
+  receiptLinkToCopy: string;
+};
+
+export function useReceiptDownload({
+  developerLightningAddress,
+  gameTitle,
+  invoice,
+  isGuestCheckout,
+  priceLabel,
+  receiptLinkToCopy,
+}: UseReceiptDownloadOptions) {
+  return useCallback(() => {
+    if (!invoice) {
+      return;
+    }
+
+    const lines = buildReceiptDownloadLines({
+      developerLightningAddress,
+      gameTitle,
+      invoice,
+      isGuestCheckout,
+      priceLabel,
+      receiptLinkToCopy,
+    });
+
+    const blob = new Blob([lines.join("\n")], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+
+    try {
+      triggerDownload(url, `bit-indie-receipt-${invoice.purchase_id}.txt`);
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }, [
+    developerLightningAddress,
+    gameTitle,
+    invoice,
+    isGuestCheckout,
+    priceLabel,
+    receiptLinkToCopy,
+  ]);
+}
+
+function triggerDownload(url: string, filename: string) {
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+}


### PR DESCRIPTION
## Summary
- consolidate latest purchase lookup logic into a reusable helper and consume it from the purchase flow hook
- break handleCreateInvoice into smaller helpers for existing purchases, authenticated invoices, and guest invoices
- extract receipt download side effects into a dedicated hook

## Testing
- yarn lint:web *(fails: workspace missing from lockfile in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea799f390832bac768f3cb2ca09aa