### PR TITLE
docs: plan accounts and developer tooling tickets

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -235,6 +235,36 @@ Post-MVP follow-up will be captured in future planning documents once the legacy
 
 ---
 
+M2 — Accounts & Developer Tooling
+- Deliver the core account system, developer console surfaces, and production-ready media assets so creators can manage their catalogs before launch.
+
+### Ticket M2-T001 — Launch Email-Based Account Flow
+- **Milestone:** M2 — Accounts & Developer Tooling
+- **Summary:** Implement the non-Nostr account creation and login experience so players and admins can authenticate without seeded profiles.
+- **Acceptance Criteria:**
+  1. Expose FastAPI routes for sign-up, login, logout, and session refresh backed by the neutral account model introduced in M8-T004.
+  2. Persist hashed credentials, profile basics, and admin flags while maintaining guest checkout for anonymous purchases.
+  3. Replace the "coming soon" login card and landing widgets with working React Query mutations that store the session and hydrate the `UserProfile` client cache.
+  4. Cover happy-path and failure flows with backend and frontend tests.
+
+### Ticket M2-T002 — Ship Developer Console Dashboard
+- **Milestone:** M2 — Accounts & Developer Tooling
+- **Summary:** Build the `/admin` dashboard that wraps `GameDraftForm`, enabling developers to manage drafts, uploads, and publish readiness.
+- **Acceptance Criteria:**
+  1. Render a secure dashboard route gated by the authenticated admin session from M2-T001.
+  2. Integrate the existing `GameDraftForm` with asset upload helpers, publish checklist status, and draft metadata editing.
+  3. Provide optimistic UI feedback and error handling for uploads and checklist actions, with tests or Storybook coverage verifying the flow.
+  4. Ensure moderation and integrity views remain accessible via the updated navigation.
+
+### Ticket M2-T003 — Replace Placeholder Media with Production Assets
+- **Milestone:** M2 — Accounts & Developer Tooling
+- **Summary:** Eliminate "coming soon" catalog imagery and receipts by seeding production-ready assets through the draft workflow.
+- **Acceptance Criteria:**
+  1. Populate launch-ready cover art, hero images, and receipt thumbnails for all catalog entries via the upload pipeline.
+  2. Update catalog, game detail, and receipt components to display the new assets while keeping fallbacks for missing media.
+  3. Add validation preventing publishes without required media and confirm staging data matches production expectations.
+  4. Document the asset seeding process for future catalog updates.
+
 M8 — Legacy Social Stack Removal
 - Strip every remaining dependency on the discontinued Nostr/zap/noted relay features.
 - Ensure the product, API, and data models no longer reference the legacy social stack while preserving current Lightning purchase flows.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,24 @@
+# Bit Indie MVP Status Review
+
+## What already works
+
+- **Storefront surfaces live data.** The landing page fetches featured rotations and the full catalog from the FastAPI backend at render time, gracefully degrading if either query fails so the UI still renders.【F:apps/web/app/page.tsx†L1-L43】
+- **Game detail pages deliver the end-to-end player flow.** Each listing loads metadata, comments, and reviews, renders verified-purchase badges, and hands off to the modal-based Lightning checkout to unlock downloads and receipts.【F:apps/web/app/games/[slug]/page.tsx†L1-L118】【F:apps/web/components/game-detail/reviews-section.tsx†L1-L83】【F:apps/web/components/game-purchase-flow/index.tsx†L1-L133】
+- **Lightning purchases wire through the API.** The purchase hook coordinates guest versus account invoices, polls invoice status, restores prior receipts, and exposes download/receipt links once payment clears.【F:apps/web/components/game-purchase-flow/hooks.ts†L1-L205】【F:apps/web/components/game-purchase-flow/hooks.ts†L205-L314】
+- **Receipts, moderation, and admin metrics have full UI + API support.** Players can load shareable receipts, while admins get queue tooling and integrity stats backed by the FastAPI routes that enforce admin checks and aggregate refund/flag metrics.【F:apps/web/app/purchases/[purchaseId]/receipt/page.tsx†L1-L167】【F:apps/web/components/admin-moderation-queue.tsx†L1-L213】【F:apps/web/components/admin-integrity-dashboard.tsx†L1-L109】【F:apps/api/src/bit_indie_api/api/v1/routes/admin.py†L39-L173】【F:apps/api/src/bit_indie_api/api/v1/routes/admin_stats.py†L1-L96】
+- **Developer services exist behind the scenes.** The API exposes draft management, asset uploads, publish checklists, and Lightning payout plumbing so a dashboard can be layered on when accounts arrive.【F:apps/api/src/bit_indie_api/api/v1/routes/game_drafts.py†L1-L177】【F:apps/api/src/bit_indie_api/services/payments.py†L1-L151】
+
+## Gaps to close before launch
+
+- **First-party authentication is still disabled.** The landing widgets and login card explicitly note that sign-in is “coming soon,” so there is no way to access admin-only surfaces without manual profile seeding. Finish the non-Nostr account flow before launch.【F:apps/web/components/landing/sections/account-access-widget.tsx†L1-L39】【F:apps/web/components/login-card.tsx†L1-L18】
+- **Developer console UI is missing.** The marketing copy links to `/admin`, but the route tree only contains moderation and stats views—no page renders the existing `GameDraftForm`, so developers cannot actually manage drafts or uploads yet.【F:apps/web/app/sell/page.tsx†L68-L110】【189bc9†L1-L2】
+- **Automated admin access and session hand-off are unresolved.** Admin dashboards rely on a `UserProfile` stored in local storage, but there is no sign-in handshake to populate it. Implement the account/session endpoints and client bridge so moderation and integrity tools gate correctly.【F:apps/web/components/admin-moderation-queue.tsx†L1-L116】【F:apps/web/lib/hooks/use-admin-integrity-metrics.ts†L1-L87】
+- **Content polish for assets remains outstanding.** Catalog tiles, hero sections, and receipts all show “Cover art coming soon” fallbacks. Ensure production uploads populate imagery and summaries before launch so the storefront doesn’t ship with placeholders.【F:apps/web/components/catalog/catalog-grid.tsx†L35-L78】【F:apps/web/components/game-detail/hero.tsx†L47-L81】【F:apps/web/app/purchases/[purchaseId]/receipt/page.tsx†L151-L215】
+
+## Suggested next steps
+
+1. Ship the account creation + login slice (backend + web) so profiles, admin gating, and developer tooling can unlock.
+2. Stand up the `/admin` dashboard that wraps `GameDraftForm`, integrates asset uploads, and surfaces publish checklist + status.
+3. Finish seeding production-ready media for the demo catalog and wire the upload pipeline into the draft form.
+
+Once those are in place, run the end-to-end Lightning checkout in staging to verify receipts, download unlocks, moderation actions, and admin metrics all round-trip correctly.


### PR DESCRIPTION
## Summary
- add a new M2 milestone covering account auth, developer console, and media readiness
- document tickets M2-T001 through M2-T003 with acceptance criteria aligned to the launch blockers

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dea780360c832babb9aec5b1eb9995