### PR TITLE
feat: developer console dashboard (M2-T002)

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -247,7 +247,7 @@ M2 — Accounts & Developer Tooling
   3. Replace the "coming soon" login card and landing widgets with working React Query mutations that store the session and hydrate the `UserProfile` client cache.
   4. Cover happy-path and failure flows with backend and frontend tests.
 
-### Ticket M2-T002 — Ship Developer Console Dashboard
+### Ticket M2-T002 — Ship Developer Console Dashboard ✅ Done
 - **Milestone:** M2 — Accounts & Developer Tooling
 - **Summary:** Build the `/admin` dashboard that wraps `GameDraftForm`, enabling developers to manage drafts, uploads, and publish readiness.
 - **Acceptance Criteria:**

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,0 +1,19 @@
+import { DeveloperDashboard } from "../../components/developer-console";
+import { MatteShell } from "../../components/layout/matte-shell";
+
+export default function AdminDashboardPage(): JSX.Element {
+  return (
+    <MatteShell variant="developer" containerClassName="mx-auto w-full max-w-5xl space-y-8 px-6 py-12">
+      <header className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#ff6b8a]">Developer dashboard</p>
+        <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Developer console</h1>
+        <p className="text-sm text-[#ffc3d0]/75">
+          Manage Lightning-ready drafts, upload builds, and monitor publish readiness without leaving the
+          admin cockpit.
+        </p>
+      </header>
+
+      <DeveloperDashboard />
+    </MatteShell>
+  );
+}

--- a/apps/web/components/developer-console/asset-upload-card.tsx
+++ b/apps/web/components/developer-console/asset-upload-card.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRef, type ChangeEventHandler } from "react";
+
+import { describeAssetUpload, type AssetKind, type AssetUploadState } from "./presenters";
+
+interface AssetUploadCardProps {
+  kind: AssetKind;
+  state: AssetUploadState;
+  disabled?: boolean;
+  onFileSelected: (file: File) => void;
+}
+
+const TITLES: Record<AssetKind, string> = {
+  cover: "Cover image upload",
+  build: "Build upload",
+};
+
+const DESCRIPTIONS: Record<AssetKind, string> = {
+  cover: "Choose a PNG or JPG under 5 MB. We optimize the image for the catalog tile automatically.",
+  build: "Upload a ZIP archive containing your executable or HTML build. We will compute the checksum and trigger a malware scan.",
+};
+
+const ACCEPT: Record<AssetKind, string> = {
+  cover: "image/png,image/jpeg",
+  build: ".zip",
+};
+
+export function AssetUploadCard({ kind, state, disabled = false, onFileSelected }: AssetUploadCardProps): JSX.Element {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const descriptor = describeAssetUpload(kind, state);
+
+  const handlePickFile = () => {
+    if (disabled) {
+      return;
+    }
+    inputRef.current?.click();
+  };
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    const file = files[0];
+    onFileSelected(file);
+    event.target.value = "";
+  };
+
+  const toneClass =
+    descriptor.tone === "success"
+      ? "text-emerald-200"
+      : descriptor.tone === "error"
+        ? "text-rose-200"
+        : descriptor.tone === "info"
+          ? "text-slate-300"
+          : "text-slate-400";
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6">
+      <header className="space-y-2">
+        <h3 className="text-lg font-semibold text-white">{TITLES[kind]}</h3>
+        <p className="text-sm text-slate-300">{DESCRIPTIONS[kind]}</p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handlePickFile}
+          disabled={disabled || state.status === "uploading"}
+          className="inline-flex items-center justify-center rounded-full border border-emerald-300/40 bg-emerald-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {state.status === "uploading" ? "Uploading…" : "Select file"}
+        </button>
+        <span className={`text-xs ${toneClass}`}>{descriptor.message}</span>
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPT[kind]}
+        className="hidden"
+        onChange={handleChange}
+        disabled={disabled || state.status === "uploading"}
+      />
+    </section>
+  );
+}

--- a/apps/web/components/developer-console/developer-dashboard.tsx
+++ b/apps/web/components/developer-console/developer-dashboard.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  GameDraftForm,
+  type GameDraftFormApi,
+} from "../game-draft-form";
+import {
+  type GameDraft,
+  type GamePublishChecklist,
+  type UserProfile,
+  becomeDeveloper,
+  createGameAssetUpload,
+  getGamePublishChecklist,
+  publishGame,
+  updateGameDraft,
+} from "../../lib/api";
+import { useStoredUserProfile } from "../../lib/hooks/use-stored-user-profile";
+import { computeSha256Hex } from "../../lib/files";
+import { performPresignedUpload } from "../../lib/uploads";
+import { saveUserProfile } from "../../lib/user-storage";
+import { AssetUploadCard } from "./asset-upload-card";
+import {
+  type AssetKind,
+  type AssetUploadState,
+  type ChecklistState,
+} from "./presenters";
+import {
+  PublishChecklistCard,
+  type PublishActionState,
+} from "./publish-checklist-card";
+
+const EMPTY_ASSET_STATE: AssetUploadState = { status: "idle", message: null };
+
+function createInitialAssetStates(): Record<AssetKind, AssetUploadState> {
+  return {
+    cover: { ...EMPTY_ASSET_STATE },
+    build: { ...EMPTY_ASSET_STATE },
+  };
+}
+
+const ADMIN_LINK_CLASS =
+  "inline-flex items-center justify-center rounded-full border border-white/15 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/80 transition hover:text-white hover:border-white/40";
+
+export function DeveloperDashboard(): JSX.Element {
+  const storedProfile = useStoredUserProfile();
+  const [profile, setProfile] = useState<UserProfile | null>(storedProfile);
+  const [formApi, setFormApi] = useState<GameDraftFormApi | null>(null);
+  const [currentDraft, setCurrentDraft] = useState<GameDraft | null>(null);
+  const [checklist, setChecklist] = useState<GamePublishChecklist | null>(null);
+  const [checklistState, setChecklistState] = useState<ChecklistState>("idle");
+  const [checklistError, setChecklistError] = useState<string | null>(null);
+  const [publishState, setPublishState] = useState<PublishActionState>({
+    status: "idle",
+    message: null,
+  });
+  const [assetStates, setAssetStates] = useState<Record<AssetKind, AssetUploadState>>(
+    () => createInitialAssetStates(),
+  );
+  const [developerState, setDeveloperState] = useState<PublishActionState>({
+    status: "idle",
+    message: null,
+  });
+
+  useEffect(() => {
+    setProfile(storedProfile);
+  }, [storedProfile]);
+
+  const handleUserUpdate = useCallback((user: UserProfile) => {
+    saveUserProfile(user);
+    setProfile(user);
+  }, []);
+
+  const handleFormApi = useCallback((api: GameDraftFormApi) => {
+    setFormApi(api);
+  }, []);
+
+  const handleDraftChange = useCallback((draft: GameDraft | null) => {
+    setCurrentDraft(draft);
+  }, []);
+
+  const updateAssetState = useCallback((kind: AssetKind, update: AssetUploadState) => {
+    setAssetStates((previous) => ({ ...previous, [kind]: update }));
+  }, []);
+
+  const resetAssetStates = useCallback(() => {
+    setAssetStates(createInitialAssetStates());
+  }, []);
+
+  const refreshChecklist = useCallback(async () => {
+    if (!profile || !profile.is_admin || !currentDraft) {
+      setChecklist(null);
+      setChecklistState("idle");
+      setChecklistError(null);
+      return;
+    }
+
+    setChecklistState("loading");
+    setChecklistError(null);
+    try {
+      const data = await getGamePublishChecklist(currentDraft.id, profile.id);
+      setChecklist(data);
+      setChecklistState("success");
+    } catch (error: unknown) {
+      setChecklistState("error");
+      if (error instanceof Error) {
+        setChecklistError(error.message);
+      } else {
+        setChecklistError("Unable to load publish requirements.");
+      }
+    }
+  }, [currentDraft, profile]);
+
+  useEffect(() => {
+    if (!currentDraft) {
+      setChecklist(null);
+      setChecklistState("idle");
+      setChecklistError(null);
+      resetAssetStates();
+      return;
+    }
+
+    void refreshChecklist();
+  }, [currentDraft, refreshChecklist, resetAssetStates]);
+
+  const handleUpload = useCallback(
+    async (kind: AssetKind, file: File) => {
+      if (!profile || !profile.is_admin) {
+        updateAssetState(kind, {
+          status: "error",
+          message: "Sign in with an admin account before uploading assets.",
+        });
+        return;
+      }
+
+      const draft = formApi?.getDraft();
+      if (!draft) {
+        updateAssetState(kind, {
+          status: "error",
+          message: "Save your draft before uploading assets.",
+        });
+        return;
+      }
+
+      updateAssetState(kind, {
+        status: "uploading",
+        message:
+          kind === "cover"
+            ? "Uploading cover image…"
+            : "Uploading build archive and computing checksum…",
+      });
+
+      try {
+        const upload = await createGameAssetUpload(draft.id, kind, {
+          user_id: profile.id,
+          filename: file.name,
+          content_type: file.type || undefined,
+          max_bytes: file.size,
+        });
+
+        await performPresignedUpload(
+          {
+            uploadUrl: upload.upload_url,
+            fields: upload.fields,
+          },
+          file,
+        );
+
+        const payload = kind === "cover"
+          ? {
+              user_id: profile.id,
+              cover_url: upload.public_url,
+            }
+          : {
+              user_id: profile.id,
+              build_object_key: upload.object_key,
+              build_size_bytes: file.size,
+              checksum_sha256: await computeSha256Hex(file),
+            };
+
+        const updated = await updateGameDraft(draft.id, payload);
+        formApi?.replaceDraft(updated);
+
+        updateAssetState(kind, {
+          status: "success",
+          message:
+            kind === "cover"
+              ? "Cover uploaded and draft updated."
+              : "Build uploaded, checksum recorded, and scan queued.",
+        });
+        setPublishState((prev) => ({
+          status: prev.status === "success" ? prev.status : "idle",
+          message: prev.status === "success" ? prev.message : null,
+        }));
+        await refreshChecklist();
+      } catch (error: unknown) {
+        updateAssetState(kind, {
+          status: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to upload asset.",
+        });
+      }
+    },
+    [formApi, profile, refreshChecklist, updateAssetState],
+  );
+
+  const handlePublish = useCallback(async () => {
+    if (!profile || !currentDraft) {
+      setPublishState({
+        status: "error",
+        message: "Save your draft and ensure you are signed in as an admin to publish.",
+      });
+      return;
+    }
+
+    setPublishState({ status: "loading", message: "Publishing draft…" });
+    try {
+      const published = await publishGame(currentDraft.id, { user_id: profile.id });
+      formApi?.replaceDraft(published);
+      setPublishState({
+        status: "success",
+        message: "Draft promoted to the unlisted catalog.",
+      });
+      await refreshChecklist();
+    } catch (error: unknown) {
+      setPublishState({
+        status: "error",
+        message:
+          error instanceof Error ? error.message : "Failed to publish draft.",
+      });
+    }
+  }, [currentDraft, formApi, profile, refreshChecklist]);
+
+  const handleBecomeDeveloper = useCallback(async () => {
+    if (!profile) {
+      return;
+    }
+
+    setDeveloperState({ status: "loading", message: "Enabling developer profile…" });
+    try {
+      await becomeDeveloper({ user_id: profile.id });
+      const updated: UserProfile = { ...profile, is_developer: true };
+      saveUserProfile(updated);
+      setProfile(updated);
+      setDeveloperState({
+        status: "success",
+        message: "Developer tools enabled for this account.",
+      });
+    } catch (error: unknown) {
+      setDeveloperState({
+        status: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Unable to enable developer tools.",
+      });
+    }
+  }, [profile]);
+
+  const quickLinks = useMemo(
+    () => [
+      { href: "/admin/mod", label: "Moderation queue" },
+      { href: "/admin/stats", label: "Integrity metrics" },
+    ],
+    [],
+  );
+
+  if (!profile) {
+    return (
+      <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6 text-sm text-slate-300">
+        <h2 className="text-lg font-semibold text-white">Sign in required</h2>
+        <p>Sign in with an administrator account to access the developer console.</p>
+      </section>
+    );
+  }
+
+  if (!profile.is_admin) {
+    return (
+      <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6 text-sm text-slate-300">
+        <h2 className="text-lg font-semibold text-white">Administrator access required</h2>
+        <p>
+          This console is limited to Bit Indie administrators. If you need access, contact the
+          operations team.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6">
+        <header className="space-y-2">
+          <h2 className="text-lg font-semibold text-white">Admin quick links</h2>
+          <p className="text-sm text-slate-300">
+            Jump directly to moderation and integrity workspaces while your draft autosaves in the
+            background.
+          </p>
+        </header>
+        <div className="flex flex-wrap gap-3">
+          {quickLinks.map((link) => (
+            <Link key={link.href} href={link.href} className={ADMIN_LINK_CLASS}>
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {!profile.is_developer ? (
+        <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6 text-sm text-slate-300">
+          <h2 className="text-lg font-semibold text-white">Enable developer tools</h2>
+          <p>
+            Create your developer profile to unlock drafting, asset uploads, and Lightning payouts.
+          </p>
+          <button
+            type="button"
+            onClick={handleBecomeDeveloper}
+            disabled={developerState.status === "loading"}
+            className="inline-flex items-center justify-center rounded-full border border-emerald-300/40 bg-emerald-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {developerState.status === "loading" ? "Enabling…" : "Enable developer profile"}
+          </button>
+          {developerState.message ? (
+            <p
+              className={`text-xs ${
+                developerState.status === "error"
+                  ? "text-rose-200"
+                  : developerState.status === "success"
+                    ? "text-emerald-200"
+                    : "text-slate-400"
+              }`}
+            >
+              {developerState.message}
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+
+      <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-8">
+          <GameDraftForm
+            user={profile}
+            onUserUpdate={handleUserUpdate}
+            onFormApi={handleFormApi}
+            onDraftChange={handleDraftChange}
+          />
+
+          <div className="space-y-6">
+            <AssetUploadCard
+              kind="cover"
+              state={assetStates.cover}
+              onFileSelected={(file) => void handleUpload("cover", file)}
+              disabled={!currentDraft}
+            />
+            <AssetUploadCard
+              kind="build"
+              state={assetStates.build}
+              onFileSelected={(file) => void handleUpload("build", file)}
+              disabled={!currentDraft}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <PublishChecklistCard
+            checklist={checklist}
+            state={checklistState}
+            error={checklistError}
+            onRefresh={() => {
+              void refreshChecklist();
+            }}
+            onPublish={() => {
+              void handlePublish();
+            }}
+            publishState={publishState}
+            disabled={!currentDraft}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/developer-console/index.ts
+++ b/apps/web/components/developer-console/index.ts
@@ -1,0 +1,8 @@
+export { DeveloperDashboard } from "./developer-dashboard";
+export { AssetUploadCard } from "./asset-upload-card";
+export { PublishChecklistCard } from "./publish-checklist-card";
+export type {
+  AssetUploadState,
+  AssetUploadStatus,
+  ChecklistState,
+} from "./presenters";

--- a/apps/web/components/developer-console/presenters.test.ts
+++ b/apps/web/components/developer-console/presenters.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeAssetUpload, describeChecklistState } from "./presenters";
+
+test("describeAssetUpload surfaces optimistic states", () => {
+  const uploading = describeAssetUpload("cover", { status: "uploading", message: "Uploading…" });
+  assert.equal(uploading.tone, "info");
+  assert.equal(uploading.message, "Uploading…");
+
+  const success = describeAssetUpload("build", { status: "success", message: null });
+  assert.equal(success.tone, "success");
+  assert.match(success.message, /build archive/i);
+
+  const error = describeAssetUpload("cover", { status: "error", message: "Upload failed" });
+  assert.equal(error.tone, "error");
+  assert.equal(error.message, "Upload failed");
+});
+
+test("describeChecklistState prioritizes readiness and errors", () => {
+  const loading = describeChecklistState({ state: "loading", error: null, checklist: null });
+  assert.equal(loading.tone, "info");
+  assert.match(loading.message, /checking/i);
+
+  const ready = describeChecklistState({
+    state: "success",
+    error: null,
+    checklist: { is_publish_ready: true, missing_requirements: [] },
+  });
+  assert.equal(ready.tone, "success");
+  assert.match(ready.message, /publish requirements are satisfied/i);
+
+  const missing = describeChecklistState({
+    state: "success",
+    error: null,
+    checklist: {
+      is_publish_ready: false,
+      missing_requirements: [
+        { code: "SUMMARY", message: "Add a summary." },
+        { code: "BUILD_UPLOAD", message: "Upload a build." },
+      ],
+    },
+  });
+  assert.equal(missing.tone, "info");
+  assert.match(missing.message, /summary/i);
+  assert.match(missing.message, /Upload a build./);
+
+  const errored = describeChecklistState({ state: "error", error: "Unable to load", checklist: null });
+  assert.equal(errored.tone, "error");
+  assert.equal(errored.message, "Unable to load");
+});

--- a/apps/web/components/developer-console/presenters.ts
+++ b/apps/web/components/developer-console/presenters.ts
@@ -1,0 +1,98 @@
+import type { GamePublishChecklist } from "../../lib/api";
+
+export type AssetKind = "cover" | "build";
+
+export type AssetUploadStatus = "idle" | "uploading" | "success" | "error";
+
+export interface AssetUploadState {
+  status: AssetUploadStatus;
+  message: string | null;
+}
+
+export type ChecklistState = "idle" | "loading" | "success" | "error";
+
+export interface ChecklistDescriptor {
+  message: string;
+  tone: "info" | "success" | "error";
+}
+
+export interface AssetUploadDescriptor {
+  message: string;
+  tone: "info" | "success" | "error" | "default";
+}
+
+const DEFAULT_UPLOAD_MESSAGES: Record<AssetKind, string> = {
+  cover: "Upload a cover image to refresh your catalog tile.",
+  build: "Upload a build archive to unlock purchases and downloads.",
+};
+
+export function describeAssetUpload(
+  kind: AssetKind,
+  state: AssetUploadState,
+): AssetUploadDescriptor {
+  const baseMessage = state.message ?? DEFAULT_UPLOAD_MESSAGES[kind];
+
+  switch (state.status) {
+    case "uploading":
+      return { message: baseMessage, tone: "info" };
+    case "success":
+      return { message: baseMessage, tone: "success" };
+    case "error":
+      return { message: baseMessage, tone: "error" };
+    default:
+      return { message: baseMessage, tone: "default" };
+  }
+}
+
+export function describeChecklistState({
+  state,
+  error,
+  checklist,
+}: {
+  state: ChecklistState;
+  error: string | null;
+  checklist: GamePublishChecklist | null;
+}): ChecklistDescriptor {
+  if (state === "loading") {
+    return {
+      tone: "info",
+      message: "Checking publish readiness…",
+    };
+  }
+
+  if (state === "error" && error) {
+    return {
+      tone: "error",
+      message: error,
+    };
+  }
+
+  if (!checklist) {
+    return {
+      tone: "info",
+      message: "Save a draft to view publish requirements.",
+    };
+  }
+
+  if (checklist.is_publish_ready) {
+    return {
+      tone: "success",
+      message: "All publish requirements are satisfied. You can promote this game now.",
+    };
+  }
+
+  if (checklist.missing_requirements.length === 0) {
+    return {
+      tone: "info",
+      message: "Keep your draft up to date to unlock the publish action.",
+    };
+  }
+
+  const missing = checklist.missing_requirements.map((item) => item.message).join(" ");
+  return {
+    tone: "info",
+    message:
+      missing ||
+      "Add a summary, description, cover image, and build upload before publishing.",
+  };
+}

--- a/apps/web/components/developer-console/publish-checklist-card.tsx
+++ b/apps/web/components/developer-console/publish-checklist-card.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { describeChecklistState, type ChecklistState } from "./presenters";
+import type { GamePublishChecklist } from "../../lib/api";
+
+export type PublishActionStatus = "idle" | "loading" | "success" | "error";
+
+export interface PublishActionState {
+  status: PublishActionStatus;
+  message: string | null;
+}
+
+interface PublishChecklistCardProps {
+  checklist: GamePublishChecklist | null;
+  state: ChecklistState;
+  error: string | null;
+  onRefresh: () => void;
+  onPublish: () => void;
+  publishState: PublishActionState;
+  disabled?: boolean;
+}
+
+export function PublishChecklistCard({
+  checklist,
+  state,
+  error,
+  onRefresh,
+  onPublish,
+  publishState,
+  disabled = false,
+}: PublishChecklistCardProps): JSX.Element {
+  const descriptor = describeChecklistState({ state, error, checklist });
+
+  const bannerClass =
+    descriptor.tone === "success"
+      ? "text-emerald-200"
+      : descriptor.tone === "error"
+        ? "text-rose-200"
+        : "text-slate-300";
+
+  const publishDisabled =
+    disabled || publishState.status === "loading" || !checklist?.is_publish_ready;
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6">
+      <header className="space-y-2">
+        <h3 className="text-lg font-semibold text-white">Publish checklist</h3>
+        <p className={`text-sm ${bannerClass}`}>{descriptor.message}</p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={disabled || state === "loading"}
+          className="inline-flex items-center justify-center rounded-full border border-emerald-300/40 bg-emerald-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {state === "loading" ? "Refreshing…" : "Refresh checklist"}
+        </button>
+        <button
+          type="button"
+          onClick={onPublish}
+          disabled={publishDisabled}
+          className="inline-flex items-center justify-center rounded-full border border-pink-400/40 bg-pink-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-pink-100 transition hover:bg-pink-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {publishState.status === "loading" ? "Publishing…" : "Publish draft"}
+        </button>
+      </div>
+
+      {publishState.message ? (
+        <p
+          className={`text-xs ${
+            publishState.status === "error"
+              ? "text-rose-200"
+              : publishState.status === "success"
+                ? "text-emerald-200"
+                : "text-slate-400"
+          }`}
+        >
+          {publishState.message}
+        </p>
+      ) : null}
+
+      {checklist && checklist.missing_requirements.length > 0 ? (
+        <ul className="space-y-2 text-sm text-slate-300">
+          {checklist.missing_requirements.map((item) => (
+            <li
+              key={item.code}
+              className="rounded-2xl border border-white/5 bg-slate-950/40 p-3 text-xs text-slate-200"
+            >
+              {item.message}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/lib/files.ts
+++ b/apps/web/lib/files.ts
@@ -1,0 +1,13 @@
+export async function computeSha256Hex(blob: Blob): Promise<string> {
+  const buffer = await blob.arrayBuffer();
+
+  if (typeof globalThis.crypto === "undefined" || !globalThis.crypto.subtle) {
+    throw new Error("Secure hashing is not available in this environment.");
+  }
+
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", buffer);
+  const bytes = new Uint8Array(digest);
+  return Array.from(bytes)
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/apps/web/lib/uploads.ts
+++ b/apps/web/lib/uploads.ts
@@ -1,0 +1,26 @@
+export interface PresignedUploadPayload {
+  uploadUrl: string;
+  fields: Record<string, string>;
+}
+
+export async function performPresignedUpload(
+  payload: PresignedUploadPayload,
+  file: File,
+): Promise<void> {
+  const formData = new FormData();
+
+  Object.entries(payload.fields).forEach(([key, value]) => {
+    formData.append(key, value);
+  });
+
+  formData.append("file", file);
+
+  const response = await fetch(payload.uploadUrl, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to upload file to storage.");
+  }
+}


### PR DESCRIPTION
## Summary
- add the /admin developer console with admin gating, quick links, and an enhanced GameDraftForm surface for draft management (M2-T002)
- wire up Lightning asset upload helpers, automatic checksum/publish checklist refresh, and optimistic feedback for cover/build uploads
- expose publish actions, update API clients for authenticated developer flows, and document ticket completion in MVPBUILDPLAN

## Testing
- npm run test --workspace apps/web
- npm run lint --workspace apps/web

------
https://chatgpt.com/codex/tasks/task_e_68deb1219774832b996b26575954e0ab