### PR TITLE
[Ticket M3-T001] Developer profile settings surface

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -173,6 +173,14 @@ M2 — Accounts & Developer Tooling
 M3 — Developer Settings
 - Creators can authenticate into a settings surface to manage Lightning payout details, core game metadata, and upload a playable build with basic validation and guidance.
 
+### Ticket M3-T001 — Developer profile settings surface ✅ Done
+- **Milestone:** M3 — Developer Settings
+- **Summary:** Add a secure developer profile API and console form so admins can publish contact email and studio URLs alongside their listings.
+- **Acceptance Criteria:**
+  1. `/v1/devs/{user_id}` returns the authenticated developer profile and both GET and POST mutations require a valid session for the matching user.
+  2. Developer console renders a profile settings form gated behind the developer flag, allowing admins to save contact email and optional studio URL.
+  3. Automated tests cover the new API authentication paths and the updated web API client helpers.
+
 M4 — Admin & Moderation
 - Provide admin-only tools to hide or restore abusive comments and reviews, enforce simple rate limits, and surface an abuse-triage dashboard for day-to-day moderation.
 

--- a/apps/api/src/bit_indie_api/api/v1/routes/developers.py
+++ b/apps/api/src/bit_indie_api/api/v1/routes/developers.py
@@ -3,14 +3,42 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from bit_indie_api.api.security import require_authenticated_user_id
 from bit_indie_api.db import get_session
 from bit_indie_api.db.models import Developer, User
 from bit_indie_api.schemas.developer import DeveloperCreateRequest, DeveloperRead
 
 
 router = APIRouter(prefix="/v1/devs", tags=["developers"])
+
+
+@router.get(
+    "/{user_id}",
+    response_model=DeveloperRead,
+    summary="Fetch the developer profile for a user",
+)
+def get_developer_profile(
+    user_id: str,
+    session: Session = Depends(get_session),
+    authenticated_user_id: str = Depends(require_authenticated_user_id),
+) -> DeveloperRead:
+    """Return the developer profile owned by the authenticated user."""
+
+    if authenticated_user_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to view this developer profile.",
+        )
+
+    statement = select(Developer).where(Developer.user_id == user_id)
+    profile = session.execute(statement).scalar_one_or_none()
+    if profile is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Developer profile not found.")
+
+    return DeveloperRead.model_validate(profile)
 
 
 @router.post(
@@ -23,8 +51,15 @@ def create_or_update_developer_profile(
     request: DeveloperCreateRequest,
     response: Response,
     session: Session = Depends(get_session),
+    authenticated_user_id: str = Depends(require_authenticated_user_id),
 ) -> DeveloperRead:
     """Create a developer profile for the given user or update the existing one."""
+
+    if authenticated_user_id != request.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to update this developer profile.",
+        )
 
     user = session.get(User, request.user_id)
     if user is None:

--- a/apps/api/tests/test_developers.py
+++ b/apps/api/tests/test_developers.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
+from bit_indie_api.core.config import clear_settings_cache, get_settings
 from bit_indie_api.db import Base, get_engine, reset_database_state, session_scope
 from bit_indie_api.db.models import Developer, User
 from bit_indie_api.main import create_application
+from bit_indie_api.services.session_tokens import create_session_token
 
 
 @pytest.fixture(autouse=True)
@@ -13,9 +15,12 @@ def _reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run each test against isolated in-memory database instances."""
 
     monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("API_SESSION_SECRET", "test-session-secret")
     reset_database_state()
+    clear_settings_cache()
     yield
     reset_database_state()
+    clear_settings_cache()
 
 
 def _create_schema() -> None:
@@ -31,6 +36,17 @@ def _build_client() -> TestClient:
     return TestClient(create_application())
 
 
+def _issue_token(user_id: str) -> str:
+    """Return a signed session token for authenticated requests."""
+
+    settings = get_settings()
+    return create_session_token(
+        user_id=user_id,
+        secret=settings.session_secret,
+        ttl_seconds=settings.session_ttl_seconds,
+    )
+
+
 def test_create_developer_profile_persists_and_returns_payload() -> None:
     """Posting to the developer endpoint should persist and return the profile."""
 
@@ -42,13 +58,18 @@ def test_create_developer_profile_persists_and_returns_payload() -> None:
         user_id = user.id
 
     client = _build_client()
+    token = _issue_token(user_id)
     payload = {
         "user_id": user_id,
         "profile_url": "https://studio.example.com",
         "contact_email": "dev@example.com",
     }
 
-    response = client.post("/v1/devs", json=payload)
+    response = client.post(
+        "/v1/devs",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
 
     assert response.status_code == 201
     body = response.json()
@@ -70,11 +91,126 @@ def test_create_developer_profile_requires_valid_user() -> None:
     _create_schema()
     client = _build_client()
 
+    token = _issue_token("missing")
     response = client.post(
         "/v1/devs",
         json={
             "user_id": "missing",
         },
+        headers={"Authorization": f"Bearer {token}"},
     )
 
     assert response.status_code == 404
+
+
+def test_get_developer_profile_requires_authentication() -> None:
+    """Requests without credentials should be rejected."""
+
+    _create_schema()
+    with session_scope() as session:
+        user = User(account_identifier="dev-auth")
+        developer = Developer(user=user)
+        session.add_all([user, developer])
+        session.flush()
+        user_id = user.id
+
+    client = _build_client()
+    response = client.get(f"/v1/devs/{user_id}")
+
+    assert response.status_code == 401
+
+
+def test_get_developer_profile_enforces_ownership() -> None:
+    """Users should not retrieve developer profiles they do not own."""
+
+    _create_schema()
+    with session_scope() as session:
+        owner = User(account_identifier="owner")
+        intruder = User(account_identifier="intruder")
+        session.add_all([owner, intruder])
+        session.flush()
+        developer = Developer(user=owner)
+        session.add(developer)
+        session.flush()
+        owner_id = owner.id
+        intruder_id = intruder.id
+
+    client = _build_client()
+    token = _issue_token(intruder_id)
+    response = client.get(
+        f"/v1/devs/{owner_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_get_developer_profile_returns_serialized_payload() -> None:
+    """The endpoint should return the persisted developer profile."""
+
+    _create_schema()
+    with session_scope() as session:
+        user = User(account_identifier="dev-user")
+        profile = Developer(
+            user=user,
+            profile_url="https://studio.example.com",
+            contact_email="studio@example.com",
+        )
+        session.add_all([user, profile])
+        session.flush()
+        user_id = user.id
+
+    client = _build_client()
+    token = _issue_token(user_id)
+    response = client.get(
+        f"/v1/devs/{user_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user_id"] == user_id
+    assert body["profile_url"] == "https://studio.example.com"
+    assert body["contact_email"] == "studio@example.com"
+
+
+def test_create_developer_profile_requires_authentication() -> None:
+    """Creating a profile without credentials should return 401."""
+
+    _create_schema()
+    with session_scope() as session:
+        user = User(account_identifier="no-auth")
+        session.add(user)
+        session.flush()
+        user_id = user.id
+
+    client = _build_client()
+    response = client.post(
+        "/v1/devs",
+        json={"user_id": user_id},
+    )
+
+    assert response.status_code == 401
+
+
+def test_create_developer_profile_rejects_mismatched_user() -> None:
+    """Users cannot manage profiles for other accounts."""
+
+    _create_schema()
+    with session_scope() as session:
+        owner = User(account_identifier="owner-2")
+        intruder = User(account_identifier="intruder-2")
+        session.add_all([owner, intruder])
+        session.flush()
+        owner_id = owner.id
+        intruder_id = intruder.id
+
+    client = _build_client()
+    token = _issue_token(intruder_id)
+    response = client.post(
+        "/v1/devs",
+        json={"user_id": owner_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 403

--- a/apps/web/components/developer-console/developer-dashboard.tsx
+++ b/apps/web/components/developer-console/developer-dashboard.tsx
@@ -31,6 +31,7 @@ import {
   PublishChecklistCard,
   type PublishActionState,
 } from "./publish-checklist-card";
+import { DeveloperProfileSettings } from "./developer-profile-settings";
 
 const EMPTY_ASSET_STATE: AssetUploadState = { status: "idle", message: null };
 
@@ -397,6 +398,7 @@ export function DeveloperDashboard(): JSX.Element {
         </div>
 
         <div className="space-y-6">
+          {profile.is_developer ? <DeveloperProfileSettings user={profile} /> : null}
           <PublishChecklistCard
             checklist={checklist}
             state={checklistState}

--- a/apps/web/components/developer-console/developer-profile-settings.tsx
+++ b/apps/web/components/developer-console/developer-profile-settings.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  getDeveloperProfile,
+  updateDeveloperProfile,
+  type DeveloperProfile,
+  type UserProfile,
+} from "../../lib/api";
+
+const labelClass = "block text-xs font-semibold uppercase tracking-[0.3em] text-slate-400";
+const inputClass =
+  "mt-2 w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white shadow-inner shadow-black/40 focus:border-emerald-400 focus:outline-none";
+const helperTextClass = "mt-1 text-xs text-slate-400";
+
+function normalizeValue(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+type FormStatus = "idle" | "loading" | "saving" | "success" | "error";
+
+interface DeveloperProfileSettingsProps {
+  user: UserProfile;
+}
+
+/**
+ * Display and update the developer profile contact settings for the signed-in user.
+ */
+export function DeveloperProfileSettings({ user }: DeveloperProfileSettingsProps): JSX.Element {
+  const [profile, setProfile] = useState<DeveloperProfile | null>(null);
+  const [contactEmail, setContactEmail] = useState<string>("");
+  const [profileUrl, setProfileUrl] = useState<string>("");
+  const [status, setStatus] = useState<FormStatus>("loading");
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus("loading");
+    setMessage(null);
+
+    void (async () => {
+      try {
+        const existing = await getDeveloperProfile(user.id);
+        if (cancelled) {
+          return;
+        }
+        setProfile(existing);
+        setContactEmail(existing.contact_email ?? "");
+        setProfileUrl(existing.profile_url ?? "");
+        setStatus("idle");
+        setMessage(null);
+      } catch (error: unknown) {
+        if (cancelled) {
+          return;
+        }
+        if (error instanceof Error && error.message === "Developer profile not found.") {
+          setProfile(null);
+          setContactEmail("");
+          setProfileUrl("");
+          setStatus("idle");
+          setMessage("Enable developer tools to publish your contact details.");
+        } else if (error instanceof Error) {
+          setStatus("error");
+          setMessage(error.message);
+        } else {
+          setStatus("error");
+          setMessage("Unable to load developer profile.");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user.id]);
+
+  const isBusy = status === "loading" || status === "saving";
+  const buttonLabel = status === "saving" ? "Saving…" : "Save profile";
+  const messageClass = useMemo(() => {
+    if (!message) {
+      return "";
+    }
+    if (status === "error") {
+      return "text-xs text-rose-200";
+    }
+    if (status === "success") {
+      return "text-xs text-emerald-200";
+    }
+    return "text-xs text-slate-400";
+  }, [message, status]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (status === "saving") {
+        return;
+      }
+
+      setStatus("saving");
+      setMessage(null);
+
+      try {
+        const updated = await updateDeveloperProfile(user.id, {
+          contact_email: normalizeValue(contactEmail),
+          profile_url: normalizeValue(profileUrl),
+        });
+        setProfile(updated);
+        setContactEmail(updated.contact_email ?? "");
+        setProfileUrl(updated.profile_url ?? "");
+        setStatus("success");
+        setMessage("Developer profile saved.");
+      } catch (error: unknown) {
+        setStatus("error");
+        if (error instanceof Error) {
+          setMessage(error.message);
+        } else {
+          setMessage("Unable to update developer profile.");
+        }
+      }
+    },
+    [contactEmail, profileUrl, status, user.id],
+  );
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6">
+      <header className="space-y-2">
+        <h2 className="text-lg font-semibold text-white">Developer profile</h2>
+        <p className="text-sm text-slate-300">
+          Share a support email and optional studio URL so players and partners can reach you.
+        </p>
+      </header>
+
+      <form className="space-y-5" onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="developer-contact-email" className={labelClass}>
+            Support contact email
+          </label>
+          <input
+            id="developer-contact-email"
+            type="email"
+            inputMode="email"
+            autoComplete="email"
+            className={inputClass}
+            placeholder="you@example.com"
+            value={contactEmail}
+            onChange={(event) => setContactEmail(event.target.value)}
+            disabled={isBusy}
+          />
+          <p className={helperTextClass}>Visible to players after you publish a build.</p>
+        </div>
+
+        <div>
+          <label htmlFor="developer-profile-url" className={labelClass}>
+            Studio or support URL
+          </label>
+          <input
+            id="developer-profile-url"
+            type="url"
+            inputMode="url"
+            autoComplete="url"
+            className={inputClass}
+            placeholder="https://studio.example.com"
+            value={profileUrl}
+            onChange={(event) => setProfileUrl(event.target.value)}
+            disabled={isBusy}
+          />
+          <p className={helperTextClass}>Optional link to your studio page or community hub.</p>
+        </div>
+
+        <button
+          type="submit"
+          disabled={isBusy}
+          className="inline-flex items-center justify-center rounded-full border border-emerald-300/40 bg-emerald-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {buttonLabel}
+        </button>
+      </form>
+
+      {message ? <p className={messageClass}>{message}</p> : null}
+
+      {profile?.verified_dev ? (
+        <p className="text-xs text-emerald-200">This profile is verified for Bit Indie launches.</p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/components/developer-console/index.ts
+++ b/apps/web/components/developer-console/index.ts
@@ -1,6 +1,7 @@
 export { DeveloperDashboard } from "./developer-dashboard";
 export { AssetUploadCard } from "./asset-upload-card";
 export { PublishChecklistCard } from "./publish-checklist-card";
+export { DeveloperProfileSettings } from "./developer-profile-settings";
 export type {
   AssetUploadState,
   AssetUploadStatus,

--- a/apps/web/lib/api/developers.test.ts
+++ b/apps/web/lib/api/developers.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  becomeDeveloper,
+  getDeveloperProfile,
+  updateDeveloperProfile,
+  type DeveloperProfile,
+} from "./developers";
+import * as userStorage from "../user-storage";
+
+async function withMockedFetch<T>(
+  implementation: typeof fetch,
+  action: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = implementation;
+  try {
+    return await action();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function withMockedToken<T>(token: string | null, action: () => Promise<T>): Promise<T> {
+  const originalLoader = userStorage.loadStoredSessionToken;
+  (userStorage as unknown as { loadStoredSessionToken: () => string | null }).loadStoredSessionToken = () => token;
+  try {
+    return await action();
+  } finally {
+    (userStorage as unknown as { loadStoredSessionToken: () => string | null }).loadStoredSessionToken = originalLoader;
+  }
+}
+
+test("developer API client", async (t) => {
+  const profile: DeveloperProfile = {
+    id: "dev-1",
+    user_id: "user-1",
+    verified_dev: false,
+    profile_url: "https://studio.example.com",
+    contact_email: "studio@example.com",
+    created_at: "2024-04-01T00:00:00Z",
+    updated_at: "2024-04-01T00:00:00Z",
+  };
+
+  await t.test("getDeveloperProfile fetches the profile with credentials", async () => {
+    await withMockedToken("session-token", async () => {
+      await withMockedFetch(async (input, init) => {
+        assert.equal(input, "http://localhost:8080/v1/devs/user-1");
+        assert.equal(init?.method, "GET");
+        const headers = new Headers(init?.headers);
+        assert.equal(headers.get("Authorization"), "Bearer session-token");
+        assert.equal(headers.get("Accept"), "application/json");
+        return new Response(JSON.stringify(profile), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }, async () => {
+        const result = await getDeveloperProfile("user-1");
+        assert.equal(result.id, profile.id);
+        assert.equal(result.contact_email, profile.contact_email);
+      });
+    });
+  });
+
+  await t.test("updateDeveloperProfile posts payload to the API", async () => {
+    await withMockedToken("session-token", async () => {
+      await withMockedFetch(async (input, init) => {
+        assert.equal(input, "http://localhost:8080/v1/devs");
+        assert.equal(init?.method, "POST");
+        const headers = new Headers(init?.headers);
+        assert.equal(headers.get("Authorization"), "Bearer session-token");
+        assert.equal(headers.get("Content-Type"), "application/json");
+        assert.equal(
+          init?.body,
+          JSON.stringify({
+            user_id: "user-1",
+            profile_url: "https://studio.example.com",
+            contact_email: "studio@example.com",
+          }),
+        );
+        return new Response(JSON.stringify(profile), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        });
+      }, async () => {
+        const result = await updateDeveloperProfile("user-1", {
+          profile_url: "https://studio.example.com",
+          contact_email: "studio@example.com",
+        });
+        assert.equal(result.user_id, profile.user_id);
+      });
+    });
+  });
+
+  await t.test("becomeDeveloper delegates to updateDeveloperProfile", async () => {
+    await withMockedToken("session-token", async () => {
+      let called = false;
+      await withMockedFetch(async (input, init) => {
+        called = true;
+        return new Response(JSON.stringify(profile), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        });
+      }, async () => {
+        const result = await becomeDeveloper({ user_id: "user-1" });
+        assert.equal(result.id, profile.id);
+      });
+      assert.equal(called, true);
+    });
+  });
+
+  await t.test("developer profile helpers require a session token", async () => {
+    await assert.rejects(
+      () =>
+        withMockedToken(null, async () => {
+          await getDeveloperProfile("user-1");
+        }),
+      /Sign in before managing your developer profile\./,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- secure the developer profile API with authenticated GET/POST support
- expose a developer profile settings form in the console to manage contact email and studio URL
- cover the new API and frontend helpers with automated tests and document completion in MVP plan

## Testing
- `npm run test --workspace apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68debcded608832b988a06e587e2fb49