### PR TITLE
[Ticket M3-T002] Lightning payout settings card

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -181,6 +181,15 @@ M3 — Developer Settings
   2. Developer console renders a profile settings form gated behind the developer flag, allowing admins to save contact email and optional studio URL.
   3. Automated tests cover the new API authentication paths and the updated web API client helpers.
 
+### Ticket M3-T002 — Lightning payout settings card ✅ Done
+- **Milestone:** M3 — Developer Settings
+- **Summary:** Add a developer console card so admins can manage Lightning payout addresses required for game sales.
+- **Acceptance Criteria:**
+  1. Developer console displays a Lightning payouts form for admin developer accounts with clear messaging and disabled states while saving.
+  2. Submitting the form persists the trimmed Lightning address via the `/v1/users/{id}/lightning-address` endpoint and refreshes the stored user profile.
+  3. Blank submissions and API failures surface actionable error messages without clearing the current address.
+  4. Automated tests cover the Lightning status helper utilities and the web API client responsible for updating Lightning addresses.
+
 M4 — Admin & Moderation
 - Provide admin-only tools to hide or restore abusive comments and reviews, enforce simple rate limits, and surface an abuse-triage dashboard for day-to-day moderation.
 

--- a/apps/web/components/developer-console/developer-dashboard.tsx
+++ b/apps/web/components/developer-console/developer-dashboard.tsx
@@ -32,6 +32,7 @@ import {
   type PublishActionState,
 } from "./publish-checklist-card";
 import { DeveloperProfileSettings } from "./developer-profile-settings";
+import { DeveloperLightningSettings } from "./developer-lightning-settings";
 
 const EMPTY_ASSET_STATE: AssetUploadState = { status: "idle", message: null };
 
@@ -398,6 +399,12 @@ export function DeveloperDashboard(): JSX.Element {
         </div>
 
         <div className="space-y-6">
+          {profile.is_developer ? (
+            <DeveloperLightningSettings
+              user={profile}
+              onUserUpdate={handleUserUpdate}
+            />
+          ) : null}
           {profile.is_developer ? <DeveloperProfileSettings user={profile} /> : null}
           <PublishChecklistCard
             checklist={checklist}

--- a/apps/web/components/developer-console/developer-lightning-settings.test.tsx
+++ b/apps/web/components/developer-console/developer-lightning-settings.test.tsx
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  describeLightningStatus,
+  normalizeLightningAddress,
+  type LightningStatusDescriptor,
+} from "./developer-lightning-settings";
+
+test("normalizeLightningAddress trims whitespace and newlines", () => {
+  assert.equal(normalizeLightningAddress(" dev@example.com "), "dev@example.com");
+  assert.equal(normalizeLightningAddress("\nlightning@wallet.test\t"), "lightning@wallet.test");
+  assert.equal(normalizeLightningAddress(""), "");
+});
+
+test("describeLightningStatus prioritizes explicit tones", () => {
+  let descriptor: LightningStatusDescriptor;
+
+  descriptor = describeLightningStatus("error", "Unable to save");
+  assert.equal(descriptor.tone, "error");
+  assert.equal(descriptor.message, "Unable to save");
+
+  descriptor = describeLightningStatus("success", "Saved");
+  assert.equal(descriptor.tone, "success");
+  assert.equal(descriptor.message, "Saved");
+
+  descriptor = describeLightningStatus("idle", "Provide an address");
+  assert.equal(descriptor.tone, "info");
+  assert.equal(descriptor.message, "Provide an address");
+
+  descriptor = describeLightningStatus("idle", null);
+  assert.equal(descriptor.tone, "info");
+  assert.match(descriptor.message, /Lightning payouts settle/i);
+});
+

--- a/apps/web/components/developer-console/developer-lightning-settings.tsx
+++ b/apps/web/components/developer-console/developer-lightning-settings.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+import { updateUserLightningAddress, type UserProfile } from "../../lib/api";
+
+const labelClass = "block text-xs font-semibold uppercase tracking-[0.3em] text-slate-400";
+const inputClass =
+  "mt-2 w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white shadow-inner shadow-black/40 focus:border-emerald-400 focus:outline-none";
+const helperTextClass = "mt-1 text-xs text-slate-400";
+const DEFAULT_STATUS_MESSAGE =
+  "Lightning payouts settle to this address once your game is live. Provide a Lightning address (name@wallet.example) or LNURL.";
+
+export type LightningFormStatus = "idle" | "saving" | "success" | "error";
+
+export interface LightningStatusDescriptor {
+  tone: "info" | "success" | "error";
+  message: string;
+}
+
+export function normalizeLightningAddress(value: string): string {
+  return value.trim();
+}
+
+export function describeLightningStatus(
+  status: LightningFormStatus,
+  message: string | null,
+): LightningStatusDescriptor {
+  if (status === "error" && message) {
+    return { tone: "error", message };
+  }
+
+  if (status === "success" && message) {
+    return { tone: "success", message };
+  }
+
+  if (message) {
+    return { tone: "info", message };
+  }
+
+  return { tone: "info", message: DEFAULT_STATUS_MESSAGE };
+}
+
+interface DeveloperLightningSettingsProps {
+  user: UserProfile;
+  onUserUpdate?: (user: UserProfile) => void;
+}
+
+/**
+ * Allow developers to manage the Lightning payout address for their studio account.
+ */
+export function DeveloperLightningSettings({
+  user,
+  onUserUpdate,
+}: DeveloperLightningSettingsProps): JSX.Element {
+  const [lightningAddress, setLightningAddress] = useState<string>(
+    user.lightning_address ?? "",
+  );
+  const [status, setStatus] = useState<LightningFormStatus>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLightningAddress(user.lightning_address ?? "");
+  }, [user.id, user.lightning_address]);
+
+  const descriptor = useMemo(
+    () => describeLightningStatus(status, message),
+    [status, message],
+  );
+
+  const messageClass = useMemo(() => {
+    switch (descriptor.tone) {
+      case "success":
+        return "text-xs text-emerald-200";
+      case "error":
+        return "text-xs text-rose-200";
+      default:
+        return "text-xs text-slate-400";
+    }
+  }, [descriptor.tone]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (status === "saving") {
+        return;
+      }
+
+      const normalized = normalizeLightningAddress(lightningAddress);
+      if (!normalized) {
+        setStatus("error");
+        setMessage("Enter a Lightning address to receive payouts.");
+        return;
+      }
+
+      const current = normalizeLightningAddress(user.lightning_address ?? "");
+      if (normalized === current) {
+        setStatus("success");
+        setMessage("Lightning address saved.");
+        return;
+      }
+
+      setStatus("saving");
+      setMessage(null);
+
+      try {
+        const updated = await updateUserLightningAddress(user.id, normalized);
+        setStatus("success");
+        setMessage("Lightning address saved.");
+        setLightningAddress(updated.lightning_address ?? "");
+        if (typeof onUserUpdate === "function") {
+          onUserUpdate(updated);
+        }
+      } catch (error: unknown) {
+        setStatus("error");
+        if (error instanceof Error) {
+          setMessage(error.message);
+        } else {
+          setMessage("Unable to update Lightning address.");
+        }
+      }
+    },
+    [lightningAddress, onUserUpdate, status, user.id, user.lightning_address],
+  );
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6">
+      <header className="space-y-2">
+        <h2 className="text-lg font-semibold text-white">Lightning payouts</h2>
+        <p className="text-sm text-slate-300">
+          Configure where Lightning purchases for your games are routed.
+        </p>
+      </header>
+
+      <form className="space-y-5" onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="developer-lightning-address" className={labelClass}>
+            Lightning address or LNURL
+          </label>
+          <input
+            id="developer-lightning-address"
+            type="text"
+            inputMode="email"
+            autoComplete="off"
+            className={inputClass}
+            placeholder="dev@wallet.example.com"
+            value={lightningAddress}
+            onChange={(event) => setLightningAddress(event.target.value)}
+            disabled={status === "saving"}
+          />
+          <p className={helperTextClass}>
+            We recommend a custodial or self-hosted wallet that supports Lightning invoices.
+          </p>
+        </div>
+
+        <button
+          type="submit"
+          disabled={status === "saving"}
+          className="inline-flex items-center justify-center rounded-full border border-emerald-300/40 bg-emerald-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status === "saving" ? "Saving…" : "Save Lightning address"}
+        </button>
+      </form>
+
+      <p className={messageClass}>{descriptor.message}</p>
+    </section>
+  );
+}
+

--- a/apps/web/components/developer-console/index.ts
+++ b/apps/web/components/developer-console/index.ts
@@ -2,6 +2,7 @@ export { DeveloperDashboard } from "./developer-dashboard";
 export { AssetUploadCard } from "./asset-upload-card";
 export { PublishChecklistCard } from "./publish-checklist-card";
 export { DeveloperProfileSettings } from "./developer-profile-settings";
+export { DeveloperLightningSettings } from "./developer-lightning-settings";
 export type {
   AssetUploadState,
   AssetUploadStatus,

--- a/apps/web/lib/api/users.test.ts
+++ b/apps/web/lib/api/users.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { updateUserLightningAddress, type UserProfile } from "./users";
+import * as userStorage from "../user-storage";
+
+async function withMockedFetch<T>(
+  implementation: typeof fetch,
+  action: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = implementation;
+  try {
+    return await action();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function withMockedToken<T>(token: string | null, action: () => Promise<T>): Promise<T> {
+  const originalLoader = userStorage.loadStoredSessionToken;
+  (userStorage as unknown as { loadStoredSessionToken: () => string | null }).loadStoredSessionToken = () => token;
+  try {
+    return await action();
+  } finally {
+    (userStorage as unknown as { loadStoredSessionToken: () => string | null }).loadStoredSessionToken = originalLoader;
+  }
+}
+
+test("updateUserLightningAddress patches the Lightning address", async (t) => {
+  const profile: UserProfile = {
+    id: "user-42",
+    account_identifier: "dev-42",
+    email: null,
+    display_name: null,
+    lightning_address: "dev@wallet.example.com",
+    reputation_score: 0,
+    is_admin: true,
+    is_developer: true,
+    created_at: "2024-04-01T00:00:00Z",
+    updated_at: "2024-04-01T00:00:00Z",
+  };
+
+  await t.test("it sends a PATCH request with credentials", async () => {
+    await withMockedToken("session-token", async () => {
+      await withMockedFetch(async (input, init) => {
+        assert.equal(input, "http://localhost:8080/v1/users/user-42/lightning-address");
+        assert.equal(init?.method, "PATCH");
+        const headers = new Headers(init?.headers);
+        assert.equal(headers.get("Authorization"), "Bearer session-token");
+        assert.equal(headers.get("Content-Type"), "application/json");
+        assert.equal(
+          init?.body,
+          JSON.stringify({ lightning_address: "dev@wallet.example.com" }),
+        );
+        return new Response(JSON.stringify(profile), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }, async () => {
+        const result = await updateUserLightningAddress("user-42", "dev@wallet.example.com");
+        assert.equal(result.id, profile.id);
+        assert.equal(result.lightning_address, profile.lightning_address);
+      });
+    });
+  });
+
+  await t.test("it requires a stored session token", async () => {
+    await assert.rejects(
+      () =>
+        withMockedToken(null, async () => {
+          await updateUserLightningAddress("user-42", "dev@wallet.example.com");
+        }),
+      /Sign in before updating your Lightning address\./,
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- Milestone: M3 — Developer Settings
- Implement a Lightning payout settings card in the developer console with validation and feedback states
- Persist Lightning address updates through the `/v1/users/{id}/lightning-address` endpoint and add helper/API tests

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68dec25d7598832b81e0cb60976a4e74