### PR TITLE
Refactor receipt lookup flow into dedicated hook

### DIFF
--- a/apps/web/components/game-purchase-flow/use-receipt-lookup.ts
+++ b/apps/web/components/game-purchase-flow/use-receipt-lookup.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useState, type FormEvent } from "react";
+
+import { extractReceiptIdFromInput } from "./receipt-handling";
+
+export function useReceiptLookupForm() {
+  const router = useRouter();
+  const [showReceiptLookup, setShowReceiptLookup] = useState(false);
+  const [manualReceiptId, setManualReceiptId] = useState("");
+
+  const handleReceiptLookupSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmed = manualReceiptId.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      setShowReceiptLookup(false);
+      setManualReceiptId("");
+      const receiptId = extractReceiptIdFromInput(trimmed);
+      router.push(`/purchases/${encodeURIComponent(receiptId)}/receipt`);
+    },
+    [manualReceiptId, router],
+  );
+
+  const toggleReceiptLookup = useCallback(() => {
+    setShowReceiptLookup((current) => {
+      const next = !current;
+      if (!next) {
+        setManualReceiptId("");
+      }
+      return next;
+    });
+  }, []);
+
+  const closeReceiptLookup = useCallback(() => {
+    setShowReceiptLookup(false);
+    setManualReceiptId("");
+  }, []);
+
+  return {
+    showReceiptLookup,
+    manualReceiptId,
+    setManualReceiptId,
+    handleReceiptLookupSubmit,
+    toggleReceiptLookup,
+    closeReceiptLookup,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- extract the receipt lookup form state management into a dedicated `useReceiptLookupForm` hook
- simplify `useGamePurchaseFlow` by delegating receipt lookup handling to the new hook

## Testing
- npm --prefix apps/web run test:build

------
https://chatgpt.com/codex/tasks/task_e_68dec4dbc3b0832ba8c9597e50a168fc