### PR TITLE
fix: compile lightning payout tests during test build

### DIFF
--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -16,12 +16,16 @@
     "lib/lightning.test.ts",
     "lib/api/comments.ts",
     "lib/api/comments.test.ts",
+    "lib/api/users.ts",
+    "lib/api/users.test.ts",
     "components/game-purchase-flow/**/*.ts",
     "components/game-purchase-flow/**/*.tsx",
     "components/ui/**/*.ts",
     "components/ui/**/*.tsx",
     "components/game-draft-form/**/*.ts",
-    "components/game-draft-form/**/*.tsx"
+    "components/game-draft-form/**/*.tsx",
+    "components/developer-console/**/*.ts",
+    "components/developer-console/**/*.tsx"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- add the developer console and user API Lightning payout tests to tsconfig.test.json so they emit to dist-tests

## Testing
- npm run test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68dec5bfa948832b9471d5a71c2536be