### PR TITLE
[Ticket M3-T003] Auto-generate game draft slugs

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -190,6 +190,14 @@ M3 — Developer Settings
   3. Blank submissions and API failures surface actionable error messages without clearing the current address.
   4. Automated tests cover the Lightning status helper utilities and the web API client responsible for updating Lightning addresses.
 
+### Ticket M3-T003 — Auto-generate game draft slugs ✅ Done
+- **Milestone:** M3 — Developer Settings
+- **Summary:** Help developers create URL-ready slugs by automatically generating one from the draft title while still allowing manual overrides.
+- **Acceptance Criteria:**
+  1. Typing a draft title pre-populates the slug input with a normalized value that updates as the title changes until the slug is manually edited.
+  2. Manually entering a slug keeps the custom value intact on subsequent title edits unless the field is cleared.
+  3. Utility tests cover the slug normalization helper to prevent regressions.
+
 M4 — Admin & Moderation
 - Provide admin-only tools to hide or restore abusive comments and reviews, enforce simple rate limits, and surface an abuse-triage dashboard for day-to-day moderation.
 

--- a/apps/web/components/game-draft-form/form-utils.test.ts
+++ b/apps/web/components/game-draft-form/form-utils.test.ts
@@ -6,6 +6,7 @@ import {
   buildCreatePayload,
   buildUpdatePayload,
   createInitialValues,
+  generateSlug,
   mapDraftToValues,
 } from "./form-utils";
 
@@ -132,4 +133,15 @@ test("mapDraftToValues flattens draft objects to form values", () => {
     build_size_bytes: "4096",
     checksum_sha256: "abc123",
   });
+});
+
+test("generateSlug normalizes whitespace and casing", () => {
+  assert.equal(generateSlug("  Solar Drift  "), "solar-drift");
+  assert.equal(generateSlug("Neon   Nights"), "neon-nights");
+});
+
+test("generateSlug collapses invalid characters", () => {
+  assert.equal(generateSlug("Rogue/Agent!"), "rogue-agent");
+  assert.equal(generateSlug("###"), "");
+  assert.equal(generateSlug("dash--chain"), "dash-chain");
 });

--- a/apps/web/components/game-draft-form/form-utils.ts
+++ b/apps/web/components/game-draft-form/form-utils.ts
@@ -44,6 +44,17 @@ export function createInitialValues(): GameDraftFormValues {
   };
 }
 
+export function generateSlug(source: string): string {
+  const normalized = source
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized;
+}
+
 export function buildCreatePayload(values: GameDraftFormValues, userId: string): CreateGameDraftRequest {
   return {
     user_id: userId,

--- a/apps/web/components/game-draft-form/index.tsx
+++ b/apps/web/components/game-draft-form/index.tsx
@@ -50,6 +50,8 @@ export function GameDraftForm({
     scanInfo,
     lastScannedAt,
     lightningAddress,
+    handleTitleChange,
+    handleSlugChange,
     handleFieldChange,
     handleLightningAddressChange,
     handleSubmit,
@@ -91,7 +93,7 @@ export function GameDraftForm({
             value={values.title}
             placeholder="Enter a working title"
             required
-            onValueChange={(value) => handleFieldChange("title", value)}
+            onValueChange={handleTitleChange}
           />
 
           <DraftInputField
@@ -103,7 +105,7 @@ export function GameDraftForm({
             required
             className="font-mono text-sm uppercase tracking-widest"
             helperText="Slugs are lower-case and appear in the public URL for your game."
-            onValueChange={(value) => handleFieldChange("slug", value)}
+            onValueChange={handleSlugChange}
           />
 
           <LightningAddressField


### PR DESCRIPTION
## Summary
- document Ticket M3-T003 as complete in the MVP plan after delivering auto-generated slugs for developer drafts
- add a reusable slug normalization helper and wire the game draft form to suggest slugs from the title until the field is manually edited
- update the draft form hook to track manual slug overrides and expose dedicated handlers while keeping automated tests for the new helper

## Testing
- npm test --workspace apps/web

------
https://chatgpt.com/codex/tasks/task_e_68dec4b91218832b9917cb2b36bc9777