### PR TITLE
refactor: centralize id normalization across web api client helpers

### DIFF
--- a/apps/web/lib/api/comments.ts
+++ b/apps/web/lib/api/comments.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "./core";
+import { requestJson, requireTrimmedValue } from "./core";
 
 export type CommentSource = "FIRST_PARTY";
 
@@ -20,10 +20,10 @@ export interface GameComment {
 }
 
 export async function getGameComments(gameId: string): Promise<GameComment[]> {
-  const normalizedId = gameId.trim();
-  if (!normalizedId) {
-    throw new Error("Game ID is required to load comments.");
-  }
+  const normalizedId = requireTrimmedValue(
+    gameId,
+    "Game ID is required to load comments.",
+  );
 
   return requestJson<GameComment[]>(`/v1/games/${encodeURIComponent(normalizedId)}/comments`, {
     cache: "no-store",

--- a/apps/web/lib/api/core.ts
+++ b/apps/web/lib/api/core.ts
@@ -29,6 +29,14 @@ function resolveApiBaseUrl(): string {
 
 export const apiBaseUrl = resolveApiBaseUrl();
 
+export function requireTrimmedValue(value: string, errorMessage: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(errorMessage);
+  }
+  return trimmed;
+}
+
 export function buildApiUrl(path: string): string {
   if (!path.startsWith("/")) {
     throw new Error(`API paths must start with a forward slash. Received: ${path}`);

--- a/apps/web/lib/api/games.ts
+++ b/apps/web/lib/api/games.ts
@@ -1,5 +1,5 @@
 import { loadStoredSessionToken } from "../user-storage";
-import { requestJson } from "./core";
+import { requestJson, requireTrimmedValue } from "./core";
 
 export type GameCategory = "PROTOTYPE" | "EARLY_ACCESS" | "FINISHED";
 
@@ -210,10 +210,7 @@ export async function createGameAssetUpload(
 }
 
 export async function getGameBySlug(slug: string): Promise<GameDraft> {
-  const normalized = slug.trim();
-  if (!normalized) {
-    throw new Error("Slug is required.");
-  }
+  const normalized = requireTrimmedValue(slug, "Slug is required.");
 
   return requestJson<GameDraft>(`/v1/games/slug/${encodeURIComponent(normalized)}`, {
     cache: "no-store",

--- a/apps/web/lib/api/moderation.ts
+++ b/apps/web/lib/api/moderation.ts
@@ -1,4 +1,4 @@
-import { buildApiUrl, parseErrorMessage } from "./core";
+import { buildApiUrl, parseErrorMessage, requireTrimmedValue } from "./core";
 
 export type ModerationTargetType = "GAME" | "COMMENT" | "REVIEW";
 export type ModerationFlagReason = "SPAM" | "TOS" | "DMCA" | "MALWARE";
@@ -80,10 +80,10 @@ export interface AdminIntegrityStats {
 }
 
 export async function getModerationQueue(userId: string): Promise<ModerationQueueItem[]> {
-  const normalizedId = userId.trim();
-  if (!normalizedId) {
-    throw new Error("Admin user ID is required to load the moderation queue.");
-  }
+  const normalizedId = requireTrimmedValue(
+    userId,
+    "Admin user ID is required to load the moderation queue.",
+  );
 
   const query = new URLSearchParams({ user_id: normalizedId });
   const response = await fetch(buildApiUrl(`/v1/admin/mod/queue?${query.toString()}`), {
@@ -139,10 +139,10 @@ export async function executeModerationTakedown(
 }
 
 export async function getAdminIntegrityStats(userId: string): Promise<AdminIntegrityStats> {
-  const normalizedId = userId.trim();
-  if (!normalizedId) {
-    throw new Error("Admin user ID is required to load integrity metrics.");
-  }
+  const normalizedId = requireTrimmedValue(
+    userId,
+    "Admin user ID is required to load integrity metrics.",
+  );
 
   const query = new URLSearchParams({ user_id: normalizedId });
   const response = await fetch(buildApiUrl(`/v1/admin/stats?${query.toString()}`), {

--- a/apps/web/lib/api/purchases.ts
+++ b/apps/web/lib/api/purchases.ts
@@ -1,4 +1,4 @@
-import { buildApiUrl, requestJson } from "./core";
+import { buildApiUrl, requestJson, requireTrimmedValue } from "./core";
 
 export type InvoiceStatus = "PENDING" | "PAID" | "EXPIRED" | "REFUNDED";
 export type RefundStatus = "NONE" | "REQUESTED" | "APPROVED" | "DENIED" | "PAID";
@@ -67,10 +67,10 @@ export async function createGameInvoice(
   gameId: string,
   payload: InvoiceCreateRequest,
 ): Promise<InvoiceCreateResponse> {
-  const normalizedId = gameId.trim();
-  if (!normalizedId) {
-    throw new Error("Game ID is required to create an invoice.");
-  }
+  const normalizedId = requireTrimmedValue(
+    gameId,
+    "Game ID is required to create an invoice.",
+  );
 
   return requestJson<InvoiceCreateResponse>(
     `/v1/games/${encodeURIComponent(normalizedId)}/invoice`,
@@ -86,15 +86,14 @@ export async function getLatestPurchaseForGame(
   gameId: string,
   userId: string,
 ): Promise<PurchaseRecord | null> {
-  const normalizedGameId = gameId.trim();
-  if (!normalizedGameId) {
-    throw new Error("Game ID is required to look up purchases.");
-  }
-
-  const normalizedUserId = userId.trim();
-  if (!normalizedUserId) {
-    throw new Error("User ID is required to look up purchases.");
-  }
+  const normalizedGameId = requireTrimmedValue(
+    gameId,
+    "Game ID is required to look up purchases.",
+  );
+  const normalizedUserId = requireTrimmedValue(
+    userId,
+    "User ID is required to look up purchases.",
+  );
 
   const url = new URL(buildApiUrl("/v1/purchases/lookup"));
   url.searchParams.set("game_id", normalizedGameId);
@@ -108,10 +107,7 @@ export async function getLatestPurchaseForGame(
 }
 
 export async function getPurchase(purchaseId: string): Promise<PurchaseRecord> {
-  const normalizedId = purchaseId.trim();
-  if (!normalizedId) {
-    throw new Error("Purchase ID is required.");
-  }
+  const normalizedId = requireTrimmedValue(purchaseId, "Purchase ID is required.");
 
   return requestJson<PurchaseRecord>(`/v1/purchases/${encodeURIComponent(normalizedId)}`, {
     cache: "no-store",
@@ -121,10 +117,7 @@ export async function getPurchase(purchaseId: string): Promise<PurchaseRecord> {
 }
 
 export async function getPurchaseReceipt(purchaseId: string): Promise<PurchaseReceipt> {
-  const normalizedId = purchaseId.trim();
-  if (!normalizedId) {
-    throw new Error("Purchase ID is required.");
-  }
+  const normalizedId = requireTrimmedValue(purchaseId, "Purchase ID is required.");
 
   return requestJson<PurchaseReceipt>(
     `/v1/purchases/${encodeURIComponent(normalizedId)}/receipt`,
@@ -137,10 +130,7 @@ export async function getPurchaseReceipt(purchaseId: string): Promise<PurchaseRe
 }
 
 export function getGameDownloadUrl(gameId: string): string {
-  const normalizedId = gameId.trim();
-  if (!normalizedId) {
-    throw new Error("Game ID is required.");
-  }
+  const normalizedId = requireTrimmedValue(gameId, "Game ID is required.");
 
   return buildApiUrl(`/v1/games/${encodeURIComponent(normalizedId)}/download`);
 }

--- a/apps/web/lib/api/reviews.ts
+++ b/apps/web/lib/api/reviews.ts
@@ -1,4 +1,4 @@
-import { buildApiUrl, parseErrorMessage } from "./core";
+import { buildApiUrl, parseErrorMessage, requireTrimmedValue } from "./core";
 
 export interface GameReviewAuthor {
   id: string;
@@ -21,10 +21,10 @@ export interface GameReview {
 }
 
 export async function getGameReviews(gameId: string): Promise<GameReview[]> {
-  const normalizedId = gameId.trim();
-  if (!normalizedId) {
-    throw new Error("Game ID is required to load reviews.");
-  }
+  const normalizedId = requireTrimmedValue(
+    gameId,
+    "Game ID is required to load reviews.",
+  );
 
   const response = await fetch(
     buildApiUrl(`/v1/games/${encodeURIComponent(normalizedId)}/reviews`),


### PR DESCRIPTION
## Summary
- add a reusable requireTrimmedValue helper to enforce non-empty identifiers in one place
- refactor game, moderation, purchase, comment, and review API wrappers to share the helper

## Testing
- npm run lint --workspace apps/web

------
https://chatgpt.com/codex/tasks/task_e_68dec73ee660832bb5cfe1d131250ea9