### PR TITLE
feat: add admin hidden content restoration tools

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -201,6 +201,14 @@ M3 — Developer Settings
 M4 — Admin & Moderation
 - Provide admin-only tools to hide or restore abusive comments and reviews, enforce simple rate limits, and surface an abuse-triage dashboard for day-to-day moderation.
 
+### Ticket M4-T001 — Hidden content triage and restoration ✅ Done
+- **Milestone:** M4 — Admin & Moderation
+- **Summary:** Expand the moderation dashboard with hidden content triage, enabling administrators to review and restore previously removed comments and reviews.
+- **Acceptance Criteria:**
+  1. `/v1/admin/mod/hidden` returns hidden comments and reviews for admin users, including associated game metadata.
+  2. `/v1/admin/mod/restore` unhides comments or reviews and dismisses related moderation flags, with automated tests covering both endpoints.
+  3. The admin moderation UI displays hidden items with restore actions that call the new API endpoints and update state after completion.
+
 M5 — Download Delivery
 - Complete the storage pipeline with uploads to S3/R2 (MinIO in dev), generate presigned download links, and enforce safe file-type and size checks before games go live.
 

--- a/apps/api/src/bit_indie_api/schemas/moderation.py
+++ b/apps/api/src/bit_indie_api/schemas/moderation.py
@@ -95,11 +95,32 @@ class ModerationActionResponse(BaseModel):
     affected_flag_ids: list[str] = Field(default_factory=list)
 
 
+class ModerationRestoreRequest(BaseModel):
+    """Administrative request to restore hidden moderated content."""
+
+    user_id: str = Field(..., description="Identifier of the acting admin user.")
+    target_type: ModerationTargetType
+    target_id: str
+
+
+class HiddenModerationItem(BaseModel):
+    """Details about hidden comments and reviews awaiting potential restoration."""
+
+    target_type: ModerationTargetType
+    target_id: str
+    created_at: datetime
+    game: FlaggedGameSummary
+    comment: FlaggedCommentSummary | None = None
+    review: FlaggedReviewSummary | None = None
+
+
 __all__ = [
     "FlaggedCommentSummary",
     "FlaggedGameSummary",
     "FlaggedReviewSummary",
     "ModerationActionResponse",
+    "ModerationRestoreRequest",
+    "HiddenModerationItem",
     "ModerationQueueItem",
     "ModerationReporter",
     "ModerationTakedownRequest",

--- a/apps/web/app/admin/mod/page.tsx
+++ b/apps/web/app/admin/mod/page.tsx
@@ -1,3 +1,4 @@
+import { AdminHiddenContent } from "../../../components/admin-hidden-content";
 import { AdminModerationQueue } from "../../../components/admin-moderation-queue";
 import { MatteShell } from "../../../components/layout/matte-shell";
 
@@ -12,7 +13,10 @@ export default function ModerationPage(): JSX.Element {
         </p>
       </header>
 
-      <AdminModerationQueue />
+      <div className="space-y-12">
+        <AdminModerationQueue />
+        <AdminHiddenContent />
+      </div>
     </MatteShell>
   );
 }

--- a/apps/web/components/admin-hidden-content.tsx
+++ b/apps/web/components/admin-hidden-content.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  HiddenModerationItem,
+  ModerationActionResponse,
+  ModerationTargetType,
+  UserProfile,
+  getHiddenModerationItems,
+  restoreModerationTarget,
+} from "../lib/api";
+import {
+  USER_PROFILE_STORAGE_EVENT,
+  loadStoredUserProfile,
+} from "../lib/user-storage";
+
+const targetDescriptions: Record<ModerationTargetType, string> = {
+  GAME: "game listing",
+  COMMENT: "comment",
+  REVIEW: "review",
+};
+
+const restoreLabels: Record<"COMMENT" | "REVIEW", string> = {
+  COMMENT: "Restore comment",
+  REVIEW: "Restore review",
+};
+
+type LoadState = "idle" | "loading" | "success" | "error";
+
+type RestorableTarget = Pick<ModerationActionResponse, "target_type" | "target_id">;
+
+function formatTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString("en-US");
+}
+
+function summarizeBody(item: HiddenModerationItem): string | null {
+  if (item.comment) {
+    return item.comment.body_md;
+  }
+  if (item.review) {
+    return item.review.body_md;
+  }
+  return null;
+}
+
+function truncate(value: string, maxLength = 220): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 1)}…`;
+}
+
+function filterAfterRestore(
+  items: HiddenModerationItem[],
+  restored: RestorableTarget,
+): HiddenModerationItem[] {
+  return items.filter(
+    (item) => !(item.target_type === restored.target_type && item.target_id === restored.target_id),
+  );
+}
+
+export function AdminHiddenContent(): JSX.Element {
+  const [profile, setProfile] = useState<UserProfile | null>(() => loadStoredUserProfile());
+  const [items, setItems] = useState<HiddenModerationItem[]>([]);
+  const [loadState, setLoadState] = useState<LoadState>("idle");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [actionTarget, setActionTarget] = useState<RestorableTarget | null>(null);
+  const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    function handleProfileChange() {
+      setProfile(loadStoredUserProfile());
+    }
+
+    window.addEventListener(USER_PROFILE_STORAGE_EVENT, handleProfileChange);
+    return () => window.removeEventListener(USER_PROFILE_STORAGE_EVENT, handleProfileChange);
+  }, []);
+
+  useEffect(() => {
+    if (!profile || !profile.is_admin) {
+      setItems([]);
+      setLoadState("idle");
+      setLoadError(null);
+    }
+  }, [profile]);
+
+  const refreshHiddenContent = useCallback(async () => {
+    if (!profile || !profile.is_admin) {
+      return;
+    }
+
+    setLoadState("loading");
+    setLoadError(null);
+    try {
+      const hiddenItems = await getHiddenModerationItems(profile.id);
+      setItems(hiddenItems);
+      setLoadState("success");
+    } catch (error: unknown) {
+      setLoadState("error");
+      if (error instanceof Error) {
+        setLoadError(error.message);
+      } else {
+        setLoadError("Failed to load hidden content.");
+      }
+    }
+  }, [profile]);
+
+  useEffect(() => {
+    if (profile && profile.is_admin) {
+      void refreshHiddenContent();
+    }
+  }, [profile, refreshHiddenContent]);
+
+  const handleRestore = useCallback(
+    async (item: HiddenModerationItem) => {
+      if (!profile || !profile.is_admin) {
+        return;
+      }
+
+      if (item.target_type === "GAME") {
+        setActionError("Game listings cannot be restored from this panel.");
+        return;
+      }
+
+      setActionTarget({ target_type: item.target_type, target_id: item.target_id });
+      setActionFeedback(null);
+      setActionError(null);
+
+      try {
+        await restoreModerationTarget({
+          user_id: profile.id,
+          target_type: item.target_type,
+          target_id: item.target_id,
+        });
+        setItems((previous) =>
+          filterAfterRestore(previous, {
+            target_type: item.target_type,
+            target_id: item.target_id,
+          }),
+        );
+        setActionFeedback("Content restored successfully.");
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setActionError(error.message);
+        } else {
+          setActionError("Failed to restore the selected content.");
+        }
+      } finally {
+        setActionTarget(null);
+      }
+    },
+    [profile],
+  );
+
+  const listIsEmpty = useMemo(
+    () => loadState === "success" && items.length === 0,
+    [loadState, items.length],
+  );
+
+  if (!profile || !profile.is_admin) {
+    return (
+      <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-8 text-sm text-slate-300">
+        <h2 className="text-lg font-semibold text-white">Hidden content</h2>
+        <p className="mt-4 text-slate-300">
+          Sign in with an administrator account to review and restore previously hidden comments and
+          reviews.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-slate-900/60 p-6 text-sm text-slate-200 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Hidden content</h2>
+          <p className="mt-2 text-slate-300">
+            Review previously hidden comments and reviews, then restore them once they are safe for the
+            community again.
+          </p>
+        </div>
+        <div className="flex items-center gap-3 self-start sm:self-auto">
+          <button
+            type="button"
+            onClick={() => void refreshHiddenContent()}
+            disabled={loadState === "loading"}
+            className="inline-flex items-center justify-center rounded-full border border-sky-300/40 bg-sky-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-sky-100 transition hover:bg-sky-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loadState === "loading" ? "Refreshing…" : "Refresh list"}
+          </button>
+        </div>
+      </div>
+
+      {loadError ? (
+        <div className="rounded-3xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-100">
+          {loadError}
+        </div>
+      ) : null}
+
+      {actionFeedback ? (
+        <div className="rounded-3xl border border-emerald-400/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+          {actionFeedback}
+        </div>
+      ) : null}
+
+      {actionError ? (
+        <div className="rounded-3xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-100">
+          {actionError}
+        </div>
+      ) : null}
+
+      {listIsEmpty ? (
+        <div className="rounded-3xl border border-white/10 bg-slate-900/40 p-6 text-sm text-slate-300">
+          <p className="font-semibold text-slate-100">No hidden items</p>
+          <p className="mt-2 text-slate-300">
+            There are no hidden comments or reviews waiting for restoration. Hidden items will appear here
+            once a takedown is reversed.
+          </p>
+        </div>
+      ) : null}
+
+      <ul className="space-y-4">
+        {items.map((item) => {
+          const summary = summarizeBody(item);
+          const isProcessing =
+            actionTarget?.target_id === item.target_id && actionTarget?.target_type === item.target_type;
+
+          const restoreLabel = restoreLabels[item.target_type as "COMMENT" | "REVIEW"];
+
+          return (
+            <li
+              key={`${item.target_type}:${item.target_id}`}
+              className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-lg shadow-sky-500/5"
+            >
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-2">
+                  <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
+                    Hidden {targetDescriptions[item.target_type]}
+                  </p>
+                  <p className="text-lg font-semibold text-white">{item.game.title}</p>
+                  <p className="text-xs text-slate-400">Slug · {item.game.slug}</p>
+                  <p className="text-xs text-slate-400">Status · {item.game.status}</p>
+                  {summary ? (
+                    <blockquote className="mt-3 rounded-2xl border border-white/5 bg-slate-950/40 p-3 text-sm text-slate-200">
+                      {truncate(summary)}
+                    </blockquote>
+                  ) : null}
+                  <p className="text-xs text-slate-500">
+                    Originally posted on {formatTimestamp(item.created_at)}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void handleRestore(item)}
+                  disabled={isProcessing}
+                  className="inline-flex items-center justify-center rounded-full border border-sky-300/50 bg-sky-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-sky-100 transition hover:bg-sky-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isProcessing ? "Restoring…" : restoreLabel}
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/lib/api/moderation.ts
+++ b/apps/web/lib/api/moderation.ts
@@ -65,6 +65,21 @@ export interface ModerationActionResponse {
   affected_flag_ids: string[];
 }
 
+export interface HiddenModerationItem {
+  target_type: ModerationTargetType;
+  target_id: string;
+  created_at: string;
+  game: ModerationFlaggedGame;
+  comment: ModerationFlaggedComment | null;
+  review: ModerationFlaggedReview | null;
+}
+
+export interface ModerationRestoreRequestPayload {
+  user_id: string;
+  target_type: Extract<ModerationTargetType, "COMMENT" | "REVIEW">;
+  target_id: string;
+}
+
 export interface AdminIntegrityStats {
   refund_rate: number;
   refunded_purchase_count: number;
@@ -132,6 +147,70 @@ export async function executeModerationTakedown(
 
   if (!response.ok) {
     const message = await parseErrorMessage(response, "Unable to apply moderation action.");
+    throw new Error(message);
+  }
+
+  return (await response.json()) as ModerationActionResponse;
+}
+
+export async function getHiddenModerationItems(userId: string): Promise<HiddenModerationItem[]> {
+  const normalizedId = requireTrimmedValue(
+    userId,
+    "Admin user ID is required to load hidden content.",
+  );
+
+  const query = new URLSearchParams({ user_id: normalizedId });
+  const response = await fetch(buildApiUrl(`/v1/admin/mod/hidden?${query.toString()}`), {
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
+
+  if (response.status === 403) {
+    throw new Error("Administrator privileges are required to view hidden content.");
+  }
+
+  if (response.status === 404) {
+    throw new Error("Admin user not found.");
+  }
+
+  if (!response.ok) {
+    const message = await parseErrorMessage(response, "Unable to load hidden content.");
+    throw new Error(message);
+  }
+
+  return (await response.json()) as HiddenModerationItem[];
+}
+
+export async function restoreModerationTarget(
+  payload: ModerationRestoreRequestPayload,
+): Promise<ModerationActionResponse> {
+  const response = await fetch(buildApiUrl("/v1/admin/mod/restore"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (response.status === 403) {
+    throw new Error("Administrator privileges are required to restore content.");
+  }
+
+  if (response.status === 404) {
+    const message = await parseErrorMessage(response, "Hidden content was not found.");
+    throw new Error(message);
+  }
+
+  if (response.status === 400) {
+    const message = await parseErrorMessage(response, "Unsupported restoration target.");
+    throw new Error(message);
+  }
+
+  if (!response.ok) {
+    const message = await parseErrorMessage(response, "Unable to restore moderated content.");
     throw new Error(message);
   }
 


### PR DESCRIPTION
## Summary
- add moderation API endpoints to list and restore hidden comments and reviews, dismissing associated flags
- extend moderation schemas, tests, and build plan to cover the new hidden-content triage workflow
- update the admin dashboard with a hidden content panel backed by new client utilities

## Testing
- PYTHONPATH=src pytest tests/test_admin_moderation.py

------
https://chatgpt.com/codex/tasks/task_e_68dec78e5ec4832b9f9592423c374966