### PR TITLE
Refactor session token utilities for web API clients

### DIFF
--- a/apps/web/components/developer-console/developer-dashboard.tsx
+++ b/apps/web/components/developer-console/developer-dashboard.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   GameDraftForm,
   type GameDraftFormApi,
-} from "../game-draft-form";
+} from "../game-draft-form/index";
 import {
   type GameDraft,
   type GamePublishChecklist,

--- a/apps/web/components/game-draft-form/index.tsx
+++ b/apps/web/components/game-draft-form/index.tsx
@@ -21,11 +21,11 @@ interface GameDraftFormProps {
   onFormApi?: (api: GameDraftFormApi) => void;
 }
 
-export interface GameDraftFormApi {
+export type GameDraftFormApi = {
   getDraft: () => GameDraft | null;
   applyFormValues: (fields: Partial<GameDraftFormValues>) => void;
   replaceDraft: (draft: GameDraft | null) => void;
-}
+};
 
 const categoryOptions: { value: GameCategory; label: string }[] = [
   { value: "PROTOTYPE", label: "Prototype" },

--- a/apps/web/lib/api/auth.ts
+++ b/apps/web/lib/api/auth.ts
@@ -1,6 +1,6 @@
 import { requestJson } from "./core";
 import type { UserProfile } from "./users";
-import { loadStoredSessionToken } from "../user-storage";
+import { optionalSessionToken, resolveSessionToken } from "./session";
 
 export interface AccountSessionResponse {
   user: UserProfile;
@@ -35,12 +35,12 @@ export async function loginAccount(request: AccountLoginRequest): Promise<Accoun
 }
 
 export async function refreshAccountSession(
-  sessionToken: string | null = loadStoredSessionToken(),
+  sessionToken?: string | null,
 ): Promise<AccountSessionResponse> {
-  const token = sessionToken ?? loadStoredSessionToken();
-  if (!token) {
-    throw new Error("Sign in to refresh your session.");
-  }
+  const token = resolveSessionToken(
+    sessionToken,
+    "Sign in to refresh your session.",
+  );
 
   return requestJson<AccountSessionResponse>("/v1/auth/refresh", {
     method: "POST",
@@ -50,8 +50,8 @@ export async function refreshAccountSession(
   });
 }
 
-export async function logoutAccount(sessionToken: string | null = loadStoredSessionToken()): Promise<void> {
-  const token = sessionToken ?? loadStoredSessionToken();
+export async function logoutAccount(sessionToken?: string | null): Promise<void> {
+  const token = optionalSessionToken(sessionToken);
   if (!token) {
     return;
   }

--- a/apps/web/lib/api/developers.ts
+++ b/apps/web/lib/api/developers.ts
@@ -1,5 +1,5 @@
 import { requestJson } from "./core";
-import { loadStoredSessionToken } from "../user-storage";
+import { resolveSessionToken } from "./session";
 
 export interface DeveloperProfile {
   id: string;
@@ -22,16 +22,11 @@ export interface UpdateDeveloperProfilePayload {
   contact_email?: string | null;
 }
 
-function getSessionTokenOrThrow(): string {
-  const token = loadStoredSessionToken();
-  if (!token) {
-    throw new Error("Sign in before managing your developer profile.");
-  }
-  return token;
-}
-
 export async function getDeveloperProfile(userId: string): Promise<DeveloperProfile> {
-  const token = getSessionTokenOrThrow();
+  const token = resolveSessionToken(
+    null,
+    "Sign in before managing your developer profile.",
+  );
   return requestJson<DeveloperProfile>(`/v1/devs/${encodeURIComponent(userId)}`, {
     method: "GET",
     headers: {
@@ -46,7 +41,10 @@ export async function updateDeveloperProfile(
   userId: string,
   payload: UpdateDeveloperProfilePayload,
 ): Promise<DeveloperProfile> {
-  const token = getSessionTokenOrThrow();
+  const token = resolveSessionToken(
+    null,
+    "Sign in before managing your developer profile.",
+  );
   return requestJson<DeveloperProfile>("/v1/devs", {
     method: "POST",
     body: JSON.stringify({

--- a/apps/web/lib/api/games.ts
+++ b/apps/web/lib/api/games.ts
@@ -1,5 +1,5 @@
-import { loadStoredSessionToken } from "../user-storage";
 import { requestJson, requireTrimmedValue } from "./core";
+import { resolveSessionToken } from "./session";
 
 export type GameCategory = "PROTOTYPE" | "EARLY_ACCESS" | "FINISHED";
 
@@ -107,20 +107,14 @@ export interface PublishGameRequest {
   user_id: string;
 }
 
-function requireSessionToken(): string {
-  const token = loadStoredSessionToken();
-  if (!token) {
-    throw new Error("Sign in to continue with developer actions.");
-  }
-
-  return token;
-}
-
 export async function createGameDraft(
   payload: CreateGameDraftRequest,
-  sessionToken: string | null = loadStoredSessionToken(),
+  sessionToken?: string | null,
 ): Promise<GameDraft> {
-  const token = sessionToken ?? requireSessionToken();
+  const token = resolveSessionToken(
+    sessionToken,
+    "Sign in to continue with developer actions.",
+  );
 
   return requestJson<GameDraft>("/v1/games", {
     method: "POST",
@@ -135,9 +129,12 @@ export async function createGameDraft(
 export async function updateGameDraft(
   gameId: string,
   payload: UpdateGameDraftRequest,
-  sessionToken: string | null = loadStoredSessionToken(),
+  sessionToken?: string | null,
 ): Promise<GameDraft> {
-  const token = sessionToken ?? requireSessionToken();
+  const token = resolveSessionToken(
+    sessionToken,
+    "Sign in to continue with developer actions.",
+  );
 
   return requestJson<GameDraft>(`/v1/games/${encodeURIComponent(gameId)}`, {
     method: "PUT",
@@ -152,9 +149,12 @@ export async function updateGameDraft(
 export async function getGamePublishChecklist(
   gameId: string,
   userId: string,
-  sessionToken: string | null = loadStoredSessionToken(),
+  sessionToken?: string | null,
 ): Promise<GamePublishChecklist> {
-  const token = sessionToken ?? requireSessionToken();
+  const token = resolveSessionToken(
+    sessionToken,
+    "Sign in to continue with developer actions.",
+  );
   const query = new URLSearchParams({ user_id: userId });
   return requestJson<GamePublishChecklist>(
     `/v1/games/${encodeURIComponent(gameId)}/publish-checklist?${query.toString()}`,
@@ -173,9 +173,12 @@ export async function getGamePublishChecklist(
 export async function publishGame(
   gameId: string,
   payload: PublishGameRequest,
-  sessionToken: string | null = loadStoredSessionToken(),
+  sessionToken?: string | null,
 ): Promise<GameDraft> {
-  const token = sessionToken ?? requireSessionToken();
+  const token = resolveSessionToken(
+    sessionToken,
+    "Sign in to continue with developer actions.",
+  );
   return requestJson<GameDraft>(`/v1/games/${encodeURIComponent(gameId)}/publish`, {
     method: "POST",
     body: JSON.stringify(payload),
@@ -192,9 +195,12 @@ export async function createGameAssetUpload(
   gameId: string,
   asset: GameAssetKind,
   payload: GameAssetUploadRequest,
-  sessionToken: string | null = loadStoredSessionToken(),
+  sessionToken?: string | null,
 ): Promise<GameAssetUploadResponse> {
-  const token = sessionToken ?? requireSessionToken();
+  const token = resolveSessionToken(
+    sessionToken,
+    "Sign in to continue with developer actions.",
+  );
   return requestJson<GameAssetUploadResponse>(
     `/v1/games/${encodeURIComponent(gameId)}/uploads/${asset}`,
     {

--- a/apps/web/lib/api/index.ts
+++ b/apps/web/lib/api/index.ts
@@ -7,3 +7,4 @@ export * from "./purchases";
 export * from "./reviews";
 export * from "./auth";
 export * from "./users";
+export * from "./session";

--- a/apps/web/lib/api/session.test.ts
+++ b/apps/web/lib/api/session.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { optionalSessionToken, resolveSessionToken } from "./session";
+import * as userStorage from "../user-storage";
+
+function withMockedToken<T>(token: string | null, action: () => T): T {
+  const originalLoader = userStorage.loadStoredSessionToken;
+  (userStorage as unknown as { loadStoredSessionToken: () => string | null }).loadStoredSessionToken = () => token;
+  try {
+    return action();
+  } finally {
+    (userStorage as unknown as { loadStoredSessionToken: () => string | null }).loadStoredSessionToken = originalLoader;
+  }
+}
+
+test("session token helpers", async (t) => {
+  await t.test("resolveSessionToken returns the provided token when available", () => {
+    const token = withMockedToken("stored-token", () =>
+      resolveSessionToken("explicit-token", "Sign in first."),
+    );
+    assert.equal(token, "explicit-token");
+  });
+
+  await t.test("resolveSessionToken falls back to the stored token", () => {
+    const token = withMockedToken("stored-token", () =>
+      resolveSessionToken(null, "Sign in first."),
+    );
+    assert.equal(token, "stored-token");
+  });
+
+  await t.test("resolveSessionToken throws when no token exists", () => {
+    assert.throws(
+      () =>
+        withMockedToken(null, () => {
+          resolveSessionToken(undefined, "Sign in first.");
+        }),
+      /Sign in first\./,
+    );
+  });
+
+  await t.test("optionalSessionToken returns the provided token", () => {
+    const token = withMockedToken("stored-token", () =>
+      optionalSessionToken("explicit-token"),
+    );
+    assert.equal(token, "explicit-token");
+  });
+
+  await t.test("optionalSessionToken returns the stored token when missing", () => {
+    const token = withMockedToken("stored-token", () => optionalSessionToken(null));
+    assert.equal(token, "stored-token");
+  });
+
+  await t.test("optionalSessionToken yields null when no token is present", () => {
+    const token = withMockedToken(null, () => optionalSessionToken(undefined));
+    assert.equal(token, null);
+  });
+});

--- a/apps/web/lib/api/session.ts
+++ b/apps/web/lib/api/session.ts
@@ -1,0 +1,27 @@
+import { loadStoredSessionToken } from "../user-storage";
+
+/**
+ * Resolve a session token by preferring an explicitly provided value and
+ * falling back to the token saved in local storage.
+ */
+export function resolveSessionToken(
+  providedToken: string | null | undefined,
+  errorMessage: string,
+): string {
+  const token = providedToken ?? loadStoredSessionToken();
+
+  if (!token) {
+    throw new Error(errorMessage);
+  }
+
+  return token;
+}
+
+/**
+ * Return the best available session token without throwing when none exists.
+ */
+export function optionalSessionToken(
+  providedToken: string | null | undefined,
+): string | null {
+  return providedToken ?? loadStoredSessionToken();
+}

--- a/apps/web/lib/api/users.ts
+++ b/apps/web/lib/api/users.ts
@@ -1,5 +1,5 @@
-import { loadStoredSessionToken } from "../user-storage";
 import { requestJson } from "./core";
+import { resolveSessionToken } from "./session";
 
 export interface UserProfile {
   id: string;
@@ -22,12 +22,11 @@ export async function updateUserLightningAddress(
   userId: string,
   lightningAddress: string,
 ): Promise<UserProfile> {
-  const sessionToken = loadStoredSessionToken();
-  if (!sessionToken) {
-    throw new Error("Sign in before updating your Lightning address.");
-  }
-
   const payload: UpdateLightningAddressRequest = { lightning_address: lightningAddress };
+  const sessionToken = resolveSessionToken(
+    null,
+    "Sign in before updating your Lightning address.",
+  );
   return requestJson<UserProfile>(`/v1/users/${encodeURIComponent(userId)}/lightning-address`, {
     method: "PATCH",
     body: JSON.stringify(payload),

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -16,6 +16,8 @@
     "lib/lightning.test.ts",
     "lib/api/comments.ts",
     "lib/api/comments.test.ts",
+    "lib/api/session.ts",
+    "lib/api/session.test.ts",
     "lib/api/users.ts",
     "lib/api/users.test.ts",
     "components/game-purchase-flow/**/*.ts",


### PR DESCRIPTION
## Summary
- add shared session token helpers so API clients consistently resolve stored credentials
- update the developer, game, user, and auth API modules to use the shared helpers and export them from the API index
- cover the new helpers with unit tests, include them in the test build, and tidy related type imports for TypeScript

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68decce52b34832b96de1164fc6c9425