### PR TITLE
feat: align landing tabs with catalog, seller, player, and chat flows

### DIFF
--- a/apps/web/components/landing/neon-landing.tsx
+++ b/apps/web/components/landing/neon-landing.tsx
@@ -4,11 +4,7 @@ import { useMemo, useState } from "react";
 
 import type { FeaturedGameSummary, GameDraft } from "../../lib/api/games";
 import { formatCategory, formatDateLabel } from "../../lib/format";
-import {
-  FALLBACK_COMMENTS,
-  FALLBACK_FEATURED,
-  FALLBACK_INVOICE_STEPS,
-} from "./landing-fallbacks";
+import { FALLBACK_COMMENTS, FALLBACK_FEATURED } from "./landing-fallbacks";
 import {
   buildChecklist,
   buildDescriptionFromMarkdown,
@@ -16,17 +12,16 @@ import {
   buildFeaturedCards,
   buildInvoice,
   buildLiveMetrics,
-  buildReceipt,
   buildReviewHighlights,
   formatSatsFromMsats,
   uppercaseLabel,
 } from "./landing-helpers";
 import { AccountAccessWidget } from "./sections/account-access-widget";
-import { GameDetailScreen } from "./sections/game-detail-screen";
-import { LightningCheckoutScreen } from "./sections/lightning-checkout-screen";
+import { CommunityChatScreen } from "./sections/community-chat-screen";
 import { LoadFailureBanner } from "./sections/load-failure-banner";
-import { ReceiptScreen } from "./sections/receipt-screen";
+import { PlayerInfoScreen } from "./sections/player-info-screen";
 import { ScreenSwitcher } from "./sections/screen-switcher";
+import { SellYourGameScreen } from "./sections/sell-your-game-screen";
 import { StorefrontScreen } from "./sections/storefront-screen";
 import { MicroLabel } from "./sections/shared";
 
@@ -110,14 +105,11 @@ export default function NeonLanding({ catalogGames, featuredSummaries, hadLoadFa
   );
 
   const comments = FALLBACK_COMMENTS;
-  const reviews = useMemo(
-    () => buildReviewHighlights(primaryGame?.title ?? FALLBACK_FEATURED[1].title),
-    [primaryGame?.title],
-  );
+  const activeGameTitle = primaryGame?.title ?? FALLBACK_FEATURED[1].title;
+  const reviews = useMemo(() => buildReviewHighlights(activeGameTitle), [activeGameTitle]);
   const checklist = useMemo(() => buildChecklist(primarySummary), [primarySummary]);
 
   const invoice = useMemo(() => buildInvoice(primaryGame), [primaryGame]);
-  const receipt = useMemo(() => buildReceipt(primaryGame, invoice), [primaryGame, invoice]);
 
   const heroMetrics = useMemo(() => computeHeroMetrics(primaryGame, primarySummary), [primaryGame, primarySummary]);
 
@@ -150,8 +142,18 @@ export default function NeonLanding({ catalogGames, featuredSummaries, hadLoadFa
             <StorefrontScreen featured={featuredCards} discover={discoverCards} metrics={liveMetrics} />
           )}
           {activeScreen === 2 && (
-            <GameDetailScreen
-              title={primaryGame?.title ?? FALLBACK_FEATURED[1].title}
+            <SellYourGameScreen
+              checklist={checklist}
+              metrics={liveMetrics}
+              lightningAddress={invoice.lightningAddress}
+              priceLabel={heroMetrics.priceLabel}
+              tipLabel={heroMetrics.tipLabel}
+              gameTitle={activeGameTitle}
+            />
+          )}
+          {activeScreen === 3 && (
+            <PlayerInfoScreen
+              title={activeGameTitle}
               statusLabel={heroMetrics.statusLabel}
               categoryLabel={heroMetrics.categoryLabel}
               versionLabel={heroMetrics.versionLabel}
@@ -162,12 +164,12 @@ export default function NeonLanding({ catalogGames, featuredSummaries, hadLoadFa
               description={detailDescription}
               comments={comments}
               reviews={reviews}
-              checklist={checklist}
               verifiedReviewsCount={primarySummary?.verified_review_count ?? 0}
             />
           )}
-          {activeScreen === 3 && <LightningCheckoutScreen invoice={invoice} steps={FALLBACK_INVOICE_STEPS} />}
-          {activeScreen === 4 && <ReceiptScreen receipt={receipt} />}
+          {activeScreen === 4 && (
+            <CommunityChatScreen comments={comments} reviews={reviews} gameTitle={activeGameTitle} />
+          )}
         </main>
       </div>
     </div>

--- a/apps/web/components/landing/sections/community-chat-screen.tsx
+++ b/apps/web/components/landing/sections/community-chat-screen.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { CommunityComment, ReviewHighlight } from "../landing-types";
+
+import { MicroLabel, NeonCard, Pill } from "./shared";
+
+type CommunityChatScreenProps = {
+  comments: CommunityComment[];
+  reviews: ReviewHighlight[];
+  gameTitle: string;
+};
+
+export function CommunityChatScreen({ comments, reviews, gameTitle }: CommunityChatScreenProps): JSX.Element {
+  return (
+    <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_18rem]">
+      <NeonCard className="p-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <MicroLabel>Chat</MicroLabel>
+          <Pill>First-party</Pill>
+        </div>
+        <p className="mt-4 max-w-2xl text-sm text-[#9fb5aa]">
+          Crew chat keeps every racer synced on the latest drops for {gameTitle}. Drop feedback, coordinate lobbies, and push
+          highlights straight to the developer feed.
+        </p>
+        <div className="mt-6 space-y-4">
+          {comments.map((comment) => (
+            <div
+              key={`${comment.author}-${comment.timeAgo}`}
+              className="rounded-2xl border border-[#1f1f1f] bg-[rgba(10,15,12,0.92)] p-4 shadow-[0_0_24px_rgba(57,255,20,0.18)]"
+            >
+              <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-[#585858]">
+                <span>{comment.author}</span>
+                <span>{comment.timeAgo}</span>
+              </div>
+              <p className="mt-3 text-sm text-[#d1f2e4]">{comment.body}</p>
+              {comment.verified ? (
+                <span className="mt-4 inline-flex items-center gap-2 text-[0.65rem] uppercase tracking-[0.35em] text-[#7bffc8]">
+                  <span className="flex h-4 w-4 items-center justify-center rounded-full border border-[#2dff85]/60 bg-[rgba(18,34,24,0.95)] text-[0.55rem] text-[#c9ffe9]">
+                    ✓
+                  </span>
+                  Verified purchase
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+        <div className="mt-6 flex w-full flex-wrap items-center gap-3">
+          <input
+            type="text"
+            placeholder="Type a message to the crew"
+            className="flex-1 min-w-[12rem] rounded-full border border-[#2dff85]/30 bg-[rgba(12,16,13,0.92)] px-4 py-3 text-sm text-[#d9ffe9] placeholder:text-[#4f6e60] focus:border-[#2dff85]/70 focus:outline-none"
+            disabled
+          />
+          <button
+            type="button"
+            className="rounded-full border border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] px-5 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-[#d9ffe9] shadow-[0_0_24px_rgba(57,255,20,0.3)] disabled:opacity-60"
+            disabled
+          >
+            Send
+          </button>
+        </div>
+        <p className="mt-2 text-[0.65rem] uppercase tracking-[0.35em] text-[#5b7a6b]">
+          Sign in to post in realtime. Crew replies refresh every few seconds.
+        </p>
+      </NeonCard>
+      <div className="space-y-6">
+        <NeonCard className="p-6">
+          <MicroLabel>Signal boosts</MicroLabel>
+          <div className="mt-4 space-y-4">
+            {reviews.map((review) => (
+              <div key={review.summary} className="rounded-2xl border border-[#1f1f1f] bg-[rgba(9,9,9,0.92)] p-4">
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-[#585858]">
+                  <span>{review.author}</span>
+                  <span>{review.helpfulLabel}</span>
+                </div>
+                <p className="mt-3 text-sm font-semibold text-white">{review.summary}</p>
+                <p className="mt-2 text-sm text-[#9fb5aa]">{review.body}</p>
+              </div>
+            ))}
+          </div>
+        </NeonCard>
+        <NeonCard className="p-6">
+          <MicroLabel>Moderation feed</MicroLabel>
+          <p className="mt-3 text-sm text-[#8fa39a]">
+            First-party moderators keep the channel signal-strong. Reports route directly to the Bit Indie team for follow-up
+            without waiting on third-party relays.
+          </p>
+          <div className="mt-4 space-y-3 text-[0.7rem] uppercase tracking-[0.35em] text-[#5b7a6b]">
+            <div className="flex items-center justify-between">
+              <span>Auto-mute spam</span>
+              <span className="rounded-full border border-[#2dff85]/40 bg-[rgba(16,28,21,0.9)] px-3 py-1 text-[0.6rem] font-semibold text-[#c7ffe9]">
+                Enabled
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Escalations today</span>
+              <span className="rounded-full border border-[#2dff85]/20 bg-[rgba(12,16,13,0.92)] px-3 py-1 text-[0.6rem] font-semibold text-[#8fa39a]">
+                0 pending
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Response time</span>
+              <span className="rounded-full border border-[#2dff85]/20 bg-[rgba(12,16,13,0.92)] px-3 py-1 text-[0.6rem] font-semibold text-[#8fa39a]">
+                &lt; 5 minutes
+              </span>
+            </div>
+          </div>
+        </NeonCard>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/landing/sections/lightning-checkout-screen.tsx
+++ b/apps/web/components/landing/sections/lightning-checkout-screen.tsx
@@ -1,10 +1,89 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 import type { InvoiceSnapshot, InvoiceStep } from "../landing-types";
 
 import { cn, MicroLabel, NeonCard, Pill } from "./shared";
 
+async function copyInvoiceToClipboard(invoiceText: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    const didCopy = await navigator.clipboard
+      .writeText(invoiceText)
+      .then(() => true)
+      .catch((error) => {
+        console.error("Failed to copy invoice via Clipboard API", error);
+        return false;
+      });
+    if (didCopy) {
+      return true;
+    }
+  }
+
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = invoiceText;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+
+  let didCopy = false;
+  const selection = document.getSelection();
+  const originalRange = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+
+  textarea.select();
+  try {
+    didCopy = document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+    if (originalRange && selection) {
+      selection.removeAllRanges();
+      selection.addRange(originalRange);
+    }
+  }
+
+  if (!didCopy) {
+    console.error("Fallback invoice copy failed using execCommand.");
+  }
+
+  return didCopy;
+}
+
 export function LightningCheckoutScreen({ invoice, steps }: { invoice: InvoiceSnapshot; steps: InvoiceStep[] }): JSX.Element {
+  const [copyState, setCopyState] = useState<"idle" | "success" | "error">("idle");
+  const [isCopying, setIsCopying] = useState(false);
+
+  useEffect(() => {
+    if (copyState === "idle") {
+      return;
+    }
+
+    const timer = window.setTimeout(() => setCopyState("idle"), 3200);
+    return () => window.clearTimeout(timer);
+  }, [copyState]);
+
+  const handleCopyInvoice = async () => {
+    if (isCopying) {
+      return;
+    }
+
+    setIsCopying(true);
+    const didCopy = await copyInvoiceToClipboard(invoice.invoiceBolt11);
+    setCopyState(didCopy ? "success" : "error");
+    setIsCopying(false);
+  };
+
+  const copyFeedbackLabel =
+    copyState === "success"
+      ? "Invoice copied to clipboard"
+      : copyState === "error"
+      ? "Unable to copy invoice. Copy it manually."
+      : null;
+
   return (
     <div className="flex justify-center">
       <NeonCard className="w-full max-w-3xl p-8">
@@ -30,11 +109,16 @@ export function LightningCheckoutScreen({ invoice, steps }: { invoice: InvoiceSn
               <div className="flex flex-wrap items-center gap-3">
                 <button
                   type="button"
-                  className="rounded-full border border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[#d9ffe9] shadow-[0_0_24px_rgba(57,255,20,0.3)]"
+                  onClick={handleCopyInvoice}
+                  disabled={isCopying}
+                  className="rounded-full border border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[#d9ffe9] shadow-[0_0_24px_rgba(57,255,20,0.3)] transition hover:border-[#7affc8] hover:text-white disabled:opacity-60"
                 >
-                  Copy invoice
+                  {isCopying ? "Copying…" : "Copy invoice"}
                 </button>
                 <span className="text-xs uppercase tracking-[0.35em] text-[#7bffc8]/70">Expires in {invoice.expiresInLabel}</span>
+                <span aria-live="polite" className="text-[0.65rem] uppercase tracking-[0.3em] text-[#7bffc8]/80">
+                  {copyFeedbackLabel}
+                </span>
               </div>
             </div>
             <div>

--- a/apps/web/components/landing/sections/player-info-screen.tsx
+++ b/apps/web/components/landing/sections/player-info-screen.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import type {
-  CommunityComment,
-  DeveloperChecklistItem,
-  ReviewHighlight,
-} from "../landing-types";
+import type { CommunityComment, ReviewHighlight } from "../landing-types";
 
-import { cn, MicroLabel, NeonCard, Pill } from "./shared";
+import { MicroLabel, NeonCard, Pill } from "./shared";
 
-type DetailGameViewProps = {
+type PlayerInfoScreenProps = {
   title: string;
   statusLabel: string;
   categoryLabel: string;
@@ -20,11 +16,10 @@ type DetailGameViewProps = {
   description: string[];
   comments: CommunityComment[];
   reviews: ReviewHighlight[];
-  checklist: DeveloperChecklistItem[];
   verifiedReviewsCount: number;
 };
 
-export function GameDetailScreen({
+export function PlayerInfoScreen({
   title,
   statusLabel,
   categoryLabel,
@@ -36,12 +31,18 @@ export function GameDetailScreen({
   description,
   comments,
   reviews,
-  checklist,
   verifiedReviewsCount,
-}: DetailGameViewProps): JSX.Element {
+}: PlayerInfoScreenProps): JSX.Element {
+  const playerChecklist = [
+    "Grab the latest build from your receipts page",
+    "Link a Lightning wallet so tips land instantly",
+    "Drop a review once you clear the first crew contract",
+  ];
+
   return (
     <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_20rem]">
       <NeonCard className="p-8">
+        <MicroLabel>Info for players</MicroLabel>
         <div className="flex flex-wrap items-center gap-3">
           <Pill>{statusLabel}</Pill>
           <Pill intent="magenta">{categoryLabel}</Pill>
@@ -56,7 +57,7 @@ export function GameDetailScreen({
           </div>
           <div className="space-y-6 text-sm text-[#9fb5aa]">
             <p className="text-base text-[#ebfff4]">
-              {title} pairs lightning-fast play with a marketplace tuned for sats.
+              {title} keeps the crew synced with Lightning receipts, instant patches, and verified community boosts.
             </p>
             <div className="space-y-3">
               {description.map((line) => (
@@ -70,23 +71,22 @@ export function GameDetailScreen({
                 type="button"
                 className="rounded-full border border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] px-5 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-[#d9ffe9] shadow-[0_0_30px_rgba(57,255,20,0.3)] transition hover:border-[#7affc8] hover:text-white"
               >
-                Launch Lightning purchase modal
+                Checkout with Lightning
               </button>
               <button
                 type="button"
                 className="rounded-full border border-[#3ab4ff]/60 bg-[rgba(12,27,33,0.9)] px-5 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-[#9bf5ff] shadow-[0_0_28px_rgba(58,180,255,0.28)] transition hover:border-[#6cd9ff]"
               >
-                Share crew invite
+                Invite your crew
               </button>
             </div>
           </div>
         </div>
         <div className="mt-10 grid gap-6 lg:grid-cols-2">
           <NeonCard className="p-6">
-            <MicroLabel>Support the developer</MicroLabel>
+            <MicroLabel>Buy & support</MicroLabel>
             <p className="mt-3 text-sm text-[#8fa39a]">
-              Lightning tips will return alongside the refreshed account system. Until then, keep the hype going by sharing
-              feedback with the team at
+              Pay in sats, keep your download synced, and share feedback directly with the crew at
               <span className="ml-2 font-semibold text-[#abffd9]">{lightningAddress ?? "their usual channels"}</span>.
             </p>
             <div className="mt-4 flex items-center justify-between">
@@ -154,21 +154,14 @@ export function GameDetailScreen({
           </div>
         </NeonCard>
         <NeonCard className="p-6">
-          <MicroLabel>Developer checklist</MicroLabel>
+          <MicroLabel>Player checklist</MicroLabel>
           <ul className="mt-4 space-y-3 text-sm text-[#b6d7c7]">
-            {checklist.map((item) => (
-              <li key={item.title} className="flex items-center gap-3">
-                <span
-                  className={cn(
-                    "flex h-6 w-6 items-center justify-center rounded-full border text-[0.65rem] font-semibold",
-                    item.complete
-                      ? "border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] text-[#c7ffe9]"
-                      : "border-[#262626] text-[#565656]",
-                  )}
-                >
-                  {item.complete ? "✓" : ""}
+            {playerChecklist.map((item) => (
+              <li key={item} className="flex items-center gap-3">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full border border-[#2dff85]/60 bg-[rgba(18,34,24,0.95)] text-[0.65rem] font-semibold text-[#c7ffe9]">
+                  ✓
                 </span>
-                <span className="uppercase tracking-[0.3em] text-[#6f7f77]">{item.title}</span>
+                <span className="uppercase tracking-[0.3em] text-[#6f7f77]">{item}</span>
               </li>
             ))}
           </ul>

--- a/apps/web/components/landing/sections/sell-your-game-screen.tsx
+++ b/apps/web/components/landing/sections/sell-your-game-screen.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import type { DeveloperChecklistItem, LiveMetrics } from "../landing-types";
+
+import { cn, MicroLabel, NeonCard, Pill } from "./shared";
+
+type SellYourGameScreenProps = {
+  checklist: DeveloperChecklistItem[];
+  metrics: LiveMetrics;
+  lightningAddress: string | null;
+  priceLabel: string;
+  tipLabel: string;
+  gameTitle: string;
+};
+
+export function SellYourGameScreen({
+  checklist,
+  metrics,
+  lightningAddress,
+  priceLabel,
+  tipLabel,
+  gameTitle,
+}: SellYourGameScreenProps): JSX.Element {
+  const developerLightningAddress = lightningAddress ?? "you@studio.dev";
+  const metricEntries = [
+    { label: "Invoices settled today", value: metrics.invoicesToday.toLocaleString("en-US") },
+    { label: "Downloads today", value: metrics.downloadsToday.toLocaleString("en-US") },
+    { label: "First-party comments", value: metrics.firstPartyComments.toLocaleString("en-US") },
+    { label: "Uptime", value: metrics.uptime },
+  ];
+
+  return (
+    <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_20rem]">
+      <NeonCard className="p-8">
+        <MicroLabel>Sell your game</MicroLabel>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <Pill>Lightning-native</Pill>
+          <Pill intent="magenta">Verified purchases</Pill>
+          <Pill intent="slate">Realtime ops</Pill>
+        </div>
+        <h2 className="mt-6 text-3xl font-semibold tracking-tight text-white">
+          Launch {gameTitle} to the catalog and start earning sats.
+        </h2>
+        <p className="mt-4 max-w-2xl text-sm text-[#9fb5aa]">
+          Connect <span className="font-semibold text-[#abffd9]">{developerLightningAddress}</span>, upload your latest build,
+          and flip on verified reviews. The developer console walks you from draft to featured slot without leaving the control
+          deck.
+        </p>
+        <div className="mt-8 grid gap-4 lg:grid-cols-2">
+          <div className="rounded-2xl border border-[#2dff85]/35 bg-[rgba(13,19,15,0.92)] p-5 shadow-[0_0_35px_rgba(57,255,20,0.22)]">
+            <MicroLabel>Lightning-ready pricing</MicroLabel>
+            <p className="mt-3 text-sm text-[#8fa39a]">
+              Your catalog price broadcasts instantly to every player browsing the marketplace. Suggested tip keeps supporters in
+              sync with your preferred range.
+            </p>
+            <div className="mt-5 grid gap-3 text-sm text-[#c2f5de] sm:grid-cols-2">
+              <div>
+                <span className="text-[0.65rem] uppercase tracking-[0.4em] text-[#7bffc8]/70">Base price</span>
+                <p className="mt-1 text-lg font-semibold text-white">{priceLabel}</p>
+              </div>
+              <div>
+                <span className="text-[0.65rem] uppercase tracking-[0.4em] text-[#7bffc8]/70">Suggested tip</span>
+                <p className="mt-1 text-lg font-semibold text-white">{tipLabel}</p>
+              </div>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-[#2dff85]/20 bg-[rgba(9,12,10,0.9)] p-5">
+            <MicroLabel>Publishing flow</MicroLabel>
+            <ul className="mt-4 space-y-3 text-sm text-[#8fa39a]">
+              <li className="flex items-start gap-3">
+                <span className="mt-1 flex h-6 w-6 items-center justify-center rounded-full border border-[#2dff85]/50 bg-[rgba(18,34,24,0.95)] text-[0.65rem] font-semibold text-[#c7ffe9]">
+                  1
+                </span>
+                <span>Upload your build & checksum straight from the dashboard.</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 flex h-6 w-6 items-center justify-center rounded-full border border-[#2dff85]/50 bg-[rgba(18,34,24,0.95)] text-[0.65rem] font-semibold text-[#c7ffe9]">
+                  2
+                </span>
+                <span>Wire in your Lightning address and preview the instant checkout flow.</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 flex h-6 w-6 items-center justify-center rounded-full border border-[#2dff85]/50 bg-[rgba(18,34,24,0.95)] text-[0.65rem] font-semibold text-[#c7ffe9]">
+                  3
+                </span>
+                <span>Flip on verified reviews to broadcast crew feedback on day one.</span>
+              </li>
+            </ul>
+            <button
+              type="button"
+              className="mt-6 w-full rounded-full border border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] px-5 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-[#d9ffe9] shadow-[0_0_28px_rgba(57,255,20,0.3)] transition hover:border-[#7affc8] hover:text-white"
+            >
+              Open developer console
+            </button>
+          </div>
+        </div>
+      </NeonCard>
+      <div className="space-y-6">
+        <NeonCard className="p-6">
+          <MicroLabel>Checklist</MicroLabel>
+          <ul className="mt-4 space-y-3 text-sm text-[#b6d7c7]">
+            {checklist.map((item) => (
+              <li key={item.title} className="flex items-center gap-3">
+                <span
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded-full border text-[0.65rem] font-semibold",
+                    item.complete
+                      ? "border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] text-[#c7ffe9]"
+                      : "border-[#262626] text-[#565656]",
+                  )}
+                >
+                  {item.complete ? "✓" : ""}
+                </span>
+                <span className="uppercase tracking-[0.3em] text-[#6f7f77]">{item.title}</span>
+              </li>
+            ))}
+          </ul>
+        </NeonCard>
+        <NeonCard className="p-6">
+          <MicroLabel>Live metrics</MicroLabel>
+          <div className="mt-4 space-y-4 text-sm text-[#8fa39a]">
+            {metricEntries.map((metric) => (
+              <div key={metric.label} className="flex items-center justify-between">
+                <span className="uppercase tracking-[0.35em] text-[#7bffc8]/70">{metric.label}</span>
+                <span className="font-semibold text-[#abffd9]">{metric.value}</span>
+              </div>
+            ))}
+          </div>
+        </NeonCard>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- restore the Catalog, Sell Your Game, Info for Players, and Chat labels in the landing screen switcher
- swap the checkout and receipt placeholders for new sell-your-game and community chat screens that match the tab names
- refresh the player info view copy and wire all three screens into the landing page flow

## Testing
- npm run lint:web

------
https://chatgpt.com/codex/tasks/task_e_68decd595244832b8a3e353c52a3f48e