### PR TITLE
feat: implement authenticated download redirects

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -151,7 +151,7 @@ M4 — Admin & Moderation
 - Hide/unhide comments and reviews; basic rate limits.
 - Admin dashboard for abuse triage.
 
-M5 — Download Delivery
+M5 — Download Delivery ✅ Done
 - S3/R2 object upload and presigned download links.
 - Safe file type and size checks.
 


### PR DESCRIPTION
## Summary
- add an authenticated GET `/v1/games/{game_id}/download` endpoint that reuses the purchase workflow to emit presigned redirects for paid buyers
- expose cache control and expiry metadata on the redirect while keeping purchase lookup/authorization errors consistent
- extend the purchase service tests to cover the new download flow and mark the M5 milestone as complete

## Testing
- PYTHONPATH=src pytest tests/test_purchases.py

------
https://chatgpt.com/codex/tasks/task_e_68ded179b13c832bae19348532d56087