### PR TITLE
feat: enforce safe storage uploads

### DIFF
--- a/apps/api/src/bit_indie_api/services/storage_policy.py
+++ b/apps/api/src/bit_indie_api/services/storage_policy.py
@@ -1,0 +1,210 @@
+"""Validation helpers for enforcing safe game asset upload parameters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable
+
+from bit_indie_api.core.config import get_settings
+from bit_indie_api.services.storage import GameAssetKind
+
+
+class AssetUploadValidationError(ValueError):
+    """Raised when a requested asset upload violates safety requirements."""
+
+
+@dataclass(frozen=True)
+class AssetUploadPolicy:
+    """Describe the allowed metadata for a game asset upload."""
+
+    allowed_extensions: tuple[str, ...]
+    allowed_content_types: tuple[str, ...]
+    max_bytes: int
+
+
+@dataclass(frozen=True)
+class ValidatedAssetUpload:
+    """Return value from validating an upload request."""
+
+    content_type: str | None
+    max_bytes: int
+
+
+class GameAssetUploadValidator:
+    """Validate filenames, content types, and sizes for game asset uploads."""
+
+    _IMAGE_EXTENSIONS: tuple[str, ...] = (".png", ".jpg", ".jpeg", ".webp", ".svg")
+    _IMAGE_CONTENT_TYPES: tuple[str, ...] = (
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "image/svg+xml",
+    )
+    _BUILD_EXTENSIONS: tuple[str, ...] = (
+        ".zip",
+        ".tar.gz",
+        ".tar.xz",
+        ".tar.bz2",
+    )
+    _BUILD_CONTENT_TYPES: tuple[str, ...] = (
+        "application/zip",
+        "application/x-zip-compressed",
+        "application/gzip",
+        "application/x-tar",
+        "application/x-xz",
+        "application/x-bzip2",
+    )
+
+    _EXTENSION_CONTENT_TYPE_MAP: dict[str, str] = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".svg": "image/svg+xml",
+        ".zip": "application/zip",
+        ".tar.gz": "application/gzip",
+        ".tar.xz": "application/x-xz",
+        ".tar.bz2": "application/x-bzip2",
+    }
+
+    def __init__(self, *, build_size_limit: int | None = None) -> None:
+        settings = get_settings()
+        self._build_size_limit = (
+            build_size_limit
+            if build_size_limit is not None
+            else settings.max_build_size_bytes
+        )
+
+    def validate(
+        self,
+        *,
+        asset: GameAssetKind,
+        filename: str,
+        content_type: str | None,
+        file_size: int | None,
+    ) -> ValidatedAssetUpload:
+        """Ensure that asset metadata matches the configured policy."""
+
+        policy = self._policy_for(asset)
+        extension = self._match_extension(filename=filename, allowed=policy.allowed_extensions)
+
+        normalized_content_type = self._normalize_content_type(content_type)
+        if normalized_content_type is None:
+            inferred = self._EXTENSION_CONTENT_TYPE_MAP.get(extension)
+            if inferred and inferred in policy.allowed_content_types:
+                normalized_content_type = inferred
+            elif policy.allowed_content_types:
+                normalized_content_type = policy.allowed_content_types[0]
+
+        if (
+            normalized_content_type
+            and policy.allowed_content_types
+            and normalized_content_type not in policy.allowed_content_types
+        ):
+            allowed_display = ", ".join(policy.allowed_content_types)
+            msg = f"Content type '{normalized_content_type}' is not allowed. Use: {allowed_display}."
+            raise AssetUploadValidationError(msg)
+
+        max_bytes = policy.max_bytes
+        if file_size is not None:
+            if file_size <= 0:
+                raise AssetUploadValidationError("File size must be greater than zero bytes.")
+            if file_size > policy.max_bytes:
+                formatted_limit = self._format_size(policy.max_bytes)
+                msg = f"File exceeds the maximum allowed size of {formatted_limit}."
+                raise AssetUploadValidationError(msg)
+            max_bytes = file_size
+
+        return ValidatedAssetUpload(content_type=normalized_content_type, max_bytes=max_bytes)
+
+    def _policy_for(self, asset: GameAssetKind) -> AssetUploadPolicy:
+        """Return the validation policy for the requested asset kind."""
+
+        if asset is GameAssetKind.BUILD:
+            return AssetUploadPolicy(
+                allowed_extensions=self._BUILD_EXTENSIONS,
+                allowed_content_types=self._BUILD_CONTENT_TYPES,
+                max_bytes=self._build_size_limit,
+            )
+
+        if asset in {GameAssetKind.COVER, GameAssetKind.HERO, GameAssetKind.RECEIPT_THUMBNAIL}:
+            limits = {
+                GameAssetKind.COVER: 5 * 1024 * 1024,
+                GameAssetKind.HERO: 8 * 1024 * 1024,
+                GameAssetKind.RECEIPT_THUMBNAIL: 3 * 1024 * 1024,
+            }
+            return AssetUploadPolicy(
+                allowed_extensions=self._IMAGE_EXTENSIONS,
+                allowed_content_types=self._IMAGE_CONTENT_TYPES,
+                max_bytes=limits[asset],
+            )
+
+        # Default to the most restrictive policy.
+        return AssetUploadPolicy(
+            allowed_extensions=self._IMAGE_EXTENSIONS,
+            allowed_content_types=self._IMAGE_CONTENT_TYPES,
+            max_bytes=3 * 1024 * 1024,
+        )
+
+    @staticmethod
+    def _match_extension(*, filename: str, allowed: Iterable[str]) -> str:
+        """Return the allowed extension that matches ``filename``."""
+
+        normalized = filename.strip().lower()
+        if not normalized:
+            raise AssetUploadValidationError("Filename is required for upload validation.")
+
+        for ext in sorted(allowed, key=len, reverse=True):
+            if normalized.endswith(ext):
+                return ext
+
+        allowed_display = ", ".join(allowed)
+        msg = f"Unsupported file extension. Allowed extensions: {allowed_display}."
+        raise AssetUploadValidationError(msg)
+
+    @staticmethod
+    def _normalize_content_type(raw: str | None) -> str | None:
+        """Normalize a content type string by removing parameters and whitespace."""
+
+        if raw is None:
+            return None
+        normalized = raw.split(";", 1)[0].strip().lower()
+        return normalized or None
+
+    @staticmethod
+    def _format_size(value: int) -> str:
+        """Return a human-readable representation of ``value`` bytes."""
+
+        units = ["bytes", "KB", "MB", "GB", "TB"]
+        size = float(value)
+        for unit in units:
+            if size < 1024 or unit == units[-1]:
+                if unit == "bytes":
+                    return f"{int(size)} bytes"
+                return f"{size:.1f} {unit}"
+            size /= 1024
+        return f"{value} bytes"
+
+
+@lru_cache(maxsize=1)
+def get_game_asset_upload_validator() -> GameAssetUploadValidator:
+    """Return a cached validator for game asset uploads."""
+
+    return GameAssetUploadValidator()
+
+
+def reset_game_asset_upload_validator() -> None:
+    """Clear the cached validator. Primarily intended for tests."""
+
+    get_game_asset_upload_validator.cache_clear()
+
+
+__all__ = [
+    "AssetUploadValidationError",
+    "AssetUploadPolicy",
+    "GameAssetUploadValidator",
+    "ValidatedAssetUpload",
+    "get_game_asset_upload_validator",
+    "reset_game_asset_upload_validator",
+]

--- a/apps/api/tests/test_services_storage_policy.py
+++ b/apps/api/tests/test_services_storage_policy.py
@@ -1,0 +1,69 @@
+import pytest
+
+from bit_indie_api.services.storage import GameAssetKind
+from bit_indie_api.services.storage_policy import (
+    AssetUploadValidationError,
+    GameAssetUploadValidator,
+    ValidatedAssetUpload,
+)
+
+
+def test_validator_infers_image_content_type() -> None:
+    """Image uploads should infer the correct content type when omitted."""
+
+    validator = GameAssetUploadValidator(build_size_limit=10 * 1024 * 1024)
+
+    result = validator.validate(
+        asset=GameAssetKind.COVER,
+        filename="promo.PNG",
+        content_type=None,
+        file_size=1024,
+    )
+
+    assert isinstance(result, ValidatedAssetUpload)
+    assert result.content_type == "image/png"
+    assert result.max_bytes == 1024
+
+
+def test_validator_rejects_unsupported_extension() -> None:
+    """Unsupported file extensions should raise a validation error."""
+
+    validator = GameAssetUploadValidator(build_size_limit=10 * 1024 * 1024)
+
+    with pytest.raises(AssetUploadValidationError):
+        validator.validate(
+            asset=GameAssetKind.COVER,
+            filename="promo.gif",
+            content_type="image/gif",
+            file_size=512,
+        )
+
+
+def test_validator_enforces_file_size_limit() -> None:
+    """Build uploads exceeding the configured size limit should be rejected."""
+
+    validator = GameAssetUploadValidator(build_size_limit=2048)
+
+    with pytest.raises(AssetUploadValidationError):
+        validator.validate(
+            asset=GameAssetKind.BUILD,
+            filename="release.zip",
+            content_type="application/zip",
+            file_size=4096,
+        )
+
+
+def test_validator_normalizes_content_type() -> None:
+    """Content type parameters should be ignored during validation."""
+
+    validator = GameAssetUploadValidator(build_size_limit=10 * 1024 * 1024)
+
+    result = validator.validate(
+        asset=GameAssetKind.HERO,
+        filename="hero.webp",
+        content_type="image/webp; charset=utf-8",
+        file_size=1500,
+    )
+
+    assert result.content_type == "image/webp"
+    assert result.max_bytes == 1500


### PR DESCRIPTION
## Summary
- add a storage upload policy validator to gate allowed file types, content types, and sizes
- require validated metadata before issuing presigned asset uploads for game drafts
- cover the validator and API behavior with targeted unit tests

## Testing
- PYTHONPATH=src pytest tests/test_services_storage_policy.py tests/test_games.py::test_create_game_asset_upload_returns_presigned_payload tests/test_games.py::test_create_game_asset_upload_validates_policy

------
https://chatgpt.com/codex/tasks/task_e_68ded618f874832b9383deb794320c89