### PR TITLE
refactor: reuse shared build scan status enum

### DIFF
--- a/apps/api/src/bit_indie_api/services/game_drafting.py
+++ b/apps/api/src/bit_indie_api/services/game_drafting.py
@@ -24,7 +24,6 @@ from bit_indie_api.services.game_promotion import update_game_featured_status
 from bit_indie_api.services.game_publication import GamePublicationService
 from bit_indie_api.services.malware_scanner import (
     BuildScanResult,
-    BuildScanStatus as ScannerBuildScanStatus,
     MalwareScannerService,
     get_malware_scanner,
 )
@@ -290,12 +289,11 @@ class BuildScanCoordinator:
             size_bytes=game.build_size_bytes,
             checksum_sha256=game.checksum_sha256,
         )
-        scanner_status = ScannerBuildScanStatus(result.status.value)
-        game.build_scan_status = BuildScanStatus(scanner_status.value)
+        game.build_scan_status = result.status
         game.build_scan_message = result.message
         game.build_scanned_at = datetime.now(timezone.utc)
 
-        if scanner_status is ScannerBuildScanStatus.FAILED:
+        if result.status is BuildScanStatus.FAILED:
             raise BuildScanFailedError(result.message)
 
 

--- a/apps/api/src/bit_indie_api/services/malware_scanner.py
+++ b/apps/api/src/bit_indie_api/services/malware_scanner.py
@@ -4,20 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
-import enum
 from typing import Iterable, Sequence
 
 from bit_indie_api.core.config import get_settings
-
-
-class BuildScanStatus(str, enum.Enum):
-    """Possible outcomes when analyzing an uploaded game build."""
-
-    NOT_SCANNED = "NOT_SCANNED"
-    PENDING = "PENDING"
-    CLEAN = "CLEAN"
-    INFECTED = "INFECTED"
-    FAILED = "FAILED"
+from bit_indie_api.db.models import BuildScanStatus
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- import the shared `BuildScanStatus` enum into the malware scanner service
- simplify the build scan coordinator to propagate scan results without enum conversion

## Testing
- PYTHONPATH=src pytest tests/test_services_game_drafting.py
- PYTHONPATH=src pytest tests/test_games.py::test_update_game_draft_applies_changes

------
https://chatgpt.com/codex/tasks/task_e_68dedb449a1c832b8715d764678b1e17