### PR TITLE
refactor: centralize build archive extensions

### DIFF
--- a/apps/api/src/bit_indie_api/services/constants.py
+++ b/apps/api/src/bit_indie_api/services/constants.py
@@ -1,0 +1,12 @@
+"""Common constants shared across service modules."""
+
+from __future__ import annotations
+
+ALLOWED_BUILD_ARCHIVE_EXTENSIONS: tuple[str, ...] = (
+    ".zip",
+    ".tar.gz",
+    ".tar.xz",
+    ".tar.bz2",
+)
+
+__all__ = ["ALLOWED_BUILD_ARCHIVE_EXTENSIONS"]

--- a/apps/api/src/bit_indie_api/services/malware_scanner.py
+++ b/apps/api/src/bit_indie_api/services/malware_scanner.py
@@ -8,6 +8,7 @@ from typing import Iterable, Sequence
 
 from bit_indie_api.core.config import get_settings
 from bit_indie_api.db.models import BuildScanStatus
+from bit_indie_api.services.constants import ALLOWED_BUILD_ARCHIVE_EXTENSIONS
 
 
 @dataclass(frozen=True)
@@ -31,7 +32,8 @@ class MalwareScannerService:
     ) -> None:
         settings = get_settings()
         self._allowed_extensions = tuple(
-            ext.lower() for ext in (allowed_extensions or (".zip", ".tar.gz", ".tar.xz", ".tar.bz2"))
+            ext.lower()
+            for ext in (allowed_extensions or ALLOWED_BUILD_ARCHIVE_EXTENSIONS)
         )
         self._blocked_extensions = tuple(
             ext.lower()

--- a/apps/api/src/bit_indie_api/services/storage_policy.py
+++ b/apps/api/src/bit_indie_api/services/storage_policy.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from typing import Iterable
 
 from bit_indie_api.core.config import get_settings
+from bit_indie_api.services.constants import ALLOWED_BUILD_ARCHIVE_EXTENSIONS
 from bit_indie_api.services.storage import GameAssetKind
 
 
@@ -41,12 +42,7 @@ class GameAssetUploadValidator:
         "image/webp",
         "image/svg+xml",
     )
-    _BUILD_EXTENSIONS: tuple[str, ...] = (
-        ".zip",
-        ".tar.gz",
-        ".tar.xz",
-        ".tar.bz2",
-    )
+    _BUILD_EXTENSIONS: tuple[str, ...] = ALLOWED_BUILD_ARCHIVE_EXTENSIONS
     _BUILD_CONTENT_TYPES: tuple[str, ...] = (
         "application/zip",
         "application/x-zip-compressed",

--- a/apps/api/tests/test_services_storage_policy.py
+++ b/apps/api/tests/test_services_storage_policy.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bit_indie_api.services.constants import ALLOWED_BUILD_ARCHIVE_EXTENSIONS
 from bit_indie_api.services.storage import GameAssetKind
 from bit_indie_api.services.storage_policy import (
     AssetUploadValidationError,
@@ -51,6 +52,16 @@ def test_validator_enforces_file_size_limit() -> None:
             content_type="application/zip",
             file_size=4096,
         )
+
+
+def test_build_policy_uses_shared_extensions() -> None:
+    """Build validation should rely on the shared build archive extensions constant."""
+
+    validator = GameAssetUploadValidator(build_size_limit=10 * 1024 * 1024)
+
+    policy = validator._policy_for(GameAssetKind.BUILD)
+
+    assert policy.allowed_extensions == ALLOWED_BUILD_ARCHIVE_EXTENSIONS
 
 
 def test_validator_normalizes_content_type() -> None:


### PR DESCRIPTION
## Summary
- add a shared ALLOWED_BUILD_ARCHIVE_EXTENSIONS constant for services
- update malware scanning and asset validation defaults to reuse the shared tuple
- extend storage policy tests to assert the build policy uses the shared extensions

## Testing
- PYTHONPATH=src pytest tests/test_services_storage_policy.py


------
https://chatgpt.com/codex/tasks/task_e_68dedd14e718832bb6820bcea452c0bb