### PR TITLE
Link landing publishing flow CTA to developer application form

### DIFF
--- a/apps/web/components/landing/sections/sell-your-game-screen.tsx
+++ b/apps/web/components/landing/sections/sell-your-game-screen.tsx
@@ -1,8 +1,13 @@
 "use client";
 
+import Link from "next/link";
+
 import type { DeveloperChecklistItem, LiveMetrics } from "../landing-types";
 
 import { cn, MicroLabel, NeonCard, Pill } from "./shared";
+
+const DEVELOPER_FORM_URL =
+  process.env.NEXT_PUBLIC_DEVELOPER_FORM_URL ?? "https://bitindie.dev/developer-form";
 
 type SellYourGameScreenProps = {
   checklist: DeveloperChecklistItem[];
@@ -86,12 +91,14 @@ export function SellYourGameScreen({
                 <span>Flip on verified reviews to broadcast crew feedback on day one.</span>
               </li>
             </ul>
-            <button
-              type="button"
-              className="mt-6 w-full rounded-full border border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] px-5 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-[#d9ffe9] shadow-[0_0_28px_rgba(57,255,20,0.3)] transition hover:border-[#7affc8] hover:text-white"
+            <Link
+              href={DEVELOPER_FORM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-6 block w-full rounded-full border border-[#2dff85]/70 bg-[rgba(18,34,24,0.95)] px-5 py-3 text-center text-xs font-semibold uppercase tracking-[0.35em] text-[#d9ffe9] shadow-[0_0_28px_rgba(57,255,20,0.3)] transition hover:border-[#7affc8] hover:text-white"
             >
-              Open developer console
-            </button>
+              Apply via the developer form
+            </Link>
           </div>
         </div>
       </NeonCard>


### PR DESCRIPTION
## Summary
- replace the Sell Your Game publishing flow button with a link to the developer application form
- allow overriding the form URL through NEXT_PUBLIC_DEVELOPER_FORM_URL while defaulting to the official form

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dedf51d03c832b959cd143e0e0fbef