### PR TITLE
feat: restore downloads from receipt links

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -134,7 +134,7 @@ Indexes: `users(account_identifier)`, `games(status, category)`, `purchases(user
 
 M1 — Core Lightning Purchase Flow
 - Implement guest checkout flow that issues Lightning invoices for purchases. ✅ Done
-- Allow players to restore receipts post-payment so they can re-download purchases.
+- Allow players to restore receipts post-payment so they can re-download purchases. ✅ Done
 
 M2 — First-Party Social Surface
 - Build comments and reviews with verified-purchase indicators for buyer feedback.

--- a/apps/api/src/bit_indie_api/api/v1/routes/purchases.py
+++ b/apps/api/src/bit_indie_api/api/v1/routes/purchases.py
@@ -160,10 +160,17 @@ def create_purchase_download_link(
     """Return a pre-signed download URL for a paid purchase."""
 
     try:
-        result = workflow.create_download_link(
-            purchase_id=purchase_id,
-            user_id=request.user_id,
-        )
+        if request.user_id is not None:
+            result = workflow.create_download_link(
+                purchase_id=purchase_id,
+                user_id=request.user_id,
+            )
+        else:
+            assert request.receipt_token is not None  # model validator guarantees one field
+            result = workflow.create_download_link_from_receipt(
+                purchase_id=purchase_id,
+                receipt_token=request.receipt_token,
+            )
     except PurchaseWorkflowError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 

--- a/apps/api/src/bit_indie_api/schemas/purchase.py
+++ b/apps/api/src/bit_indie_api/schemas/purchase.py
@@ -75,7 +75,19 @@ class OpenNodeWebhookPayload(BaseModel):
 class PurchaseDownloadRequest(BaseModel):
     """Request payload for generating a signed download link."""
 
-    user_id: str = Field(..., min_length=1)
+    user_id: str | None = Field(default=None, min_length=1)
+    receipt_token: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def validate_actor(self) -> "PurchaseDownloadRequest":
+        """Ensure callers provide exactly one credential for download access."""
+
+        has_user = bool(self.user_id)
+        has_token = bool(self.receipt_token)
+        if has_user == has_token:
+            msg = "Provide either user_id or receipt_token to request a download link."
+            raise ValueError(msg)
+        return self
 
 
 class PurchaseDownloadResponse(BaseModel):

--- a/apps/web/app/purchases/[purchaseId]/receipt/page.tsx
+++ b/apps/web/app/purchases/[purchaseId]/receipt/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 
 import type { InvoiceStatus, PurchaseReceipt } from "../../../../lib/api";
 import { getPurchaseReceipt } from "../../../../lib/api";
+import { ReceiptDownloadActions } from "./restore-download";
 import { MatteShell } from "../../../../components/layout/matte-shell";
 
 type PurchaseReceiptPageProps = {
@@ -197,26 +198,18 @@ export default async function PurchaseReceiptPage({
 
           <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-[#dcfff2]/80">
             <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-[#7bffc8]/70">Next steps</h2>
-            {purchase.invoice_status === "PAID" ? (
-              <p className="mt-3">
-                Head back to the game page to grab the latest build. If you paid as a guest, keep this receipt handy to restore downloads on any device.
-              </p>
-            ) : (
-              <p className="mt-3">
-                Pay the Lightning invoice from any compatible wallet. We&apos;ll unlock the download automatically once payment is confirmed.
-              </p>
-            )}
+            <ReceiptDownloadActions
+              purchaseId={purchase.id}
+              invoiceStatus={purchase.invoice_status}
+              downloadGranted={purchase.download_granted}
+              buildAvailable={game.build_available}
+            />
             <Link
               href={gameUrl}
               className="mt-5 inline-flex w-full items-center justify-center rounded-full border border-[#7bffc8]/60 bg-[#7bffc8]/20 px-4 py-2 text-sm font-semibold text-white transition hover:border-[#7bffc8] hover:text-[#050505] hover:bg-[#7bffc8]/90"
             >
               View game page
             </Link>
-            {game.build_available ? null : (
-              <p className="mt-3 text-xs text-[#b8ffe5]/60">
-                The developer hasn&apos;t uploaded a downloadable build yet. You&apos;ll receive access as soon as it&apos;s available.
-              </p>
-            )}
           </div>
         </aside>
       </section>

--- a/apps/web/app/purchases/[purchaseId]/receipt/restore-download.tsx
+++ b/apps/web/app/purchases/[purchaseId]/receipt/restore-download.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import type { InvoiceStatus } from "../../../../lib/api";
+import { restorePurchaseDownload } from "../../../../lib/api";
+
+type ReceiptDownloadActionsProps = {
+  purchaseId: string;
+  invoiceStatus: InvoiceStatus;
+  downloadGranted: boolean;
+  buildAvailable: boolean;
+};
+
+export function ReceiptDownloadActions({
+  purchaseId,
+  invoiceStatus,
+  downloadGranted,
+  buildAvailable,
+}: ReceiptDownloadActionsProps): JSX.Element {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleRestore = useCallback(async () => {
+    setErrorMessage(null);
+    setIsLoading(true);
+    try {
+      const response = await restorePurchaseDownload(purchaseId);
+      window.location.assign(response.download_url);
+    } catch (error) {
+      console.error("Failed to restore download from receipt", error);
+      if (error instanceof Error) {
+        if (error.message === "Purchase is not eligible for download.") {
+          setErrorMessage("Payment confirmation is still processing. Try again soon.");
+          return;
+        }
+        if (error.message === "Game build is not available for download.") {
+          setErrorMessage("The developer hasn't uploaded a downloadable build yet.");
+          return;
+        }
+        setErrorMessage(error.message);
+        return;
+      }
+      setErrorMessage("Unable to open the download link. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [purchaseId]);
+
+  if (invoiceStatus !== "PAID") {
+    return (
+      <p className="mt-3 text-sm text-[#dcfff2]/80">
+        Pay the Lightning invoice to unlock this download. We'll refresh the receipt once payment is detected.
+      </p>
+    );
+  }
+
+  if (!downloadGranted) {
+    return (
+      <p className="mt-3 text-sm text-[#dcfff2]/80">
+        This purchase is still finalizing. Check back shortly or contact support if the download remains locked.
+      </p>
+    );
+  }
+
+  if (!buildAvailable) {
+    return (
+      <p className="mt-3 text-sm text-[#dcfff2]/80">
+        The developer hasn't uploaded a downloadable build yet. You'll be able to restore the download here once it's ready.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-5 space-y-3">
+      <button
+        type="button"
+        onClick={handleRestore}
+        disabled={isLoading}
+        className="inline-flex w-full items-center justify-center rounded-full border border-[#7bffc8]/60 bg-[#7bffc8]/20 px-4 py-2 text-sm font-semibold text-white transition hover:border-[#7bffc8] hover:bg-[#7bffc8]/90 hover:text-[#050505] disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {isLoading ? "Preparing download…" : "Restore download"}
+      </button>
+      {errorMessage ? (
+        <p className="text-xs text-rose-200/80">{errorMessage}</p>
+      ) : (
+        <p className="text-xs text-[#b8ffe5]/60">
+          We'll open a fresh signed link to the latest build. Keep this receipt handy so you can restore downloads on new devices.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/game-purchase-flow/download-unlocked-card.tsx
+++ b/apps/web/components/game-purchase-flow/download-unlocked-card.tsx
@@ -3,11 +3,14 @@ import { ReceiptActions } from "./receipt-actions";
 
 type DownloadUnlockedCardProps = {
   buildAvailable: boolean;
-  downloadUrl: string;
+  downloadUrl: string | null;
   receiptLink: string;
   receiptCopyState: CopyState;
   onCopyReceiptLink: () => void;
   onDownloadReceipt: () => void;
+  onRequestDownload?: () => void;
+  isDownloadRequestPending?: boolean;
+  downloadError?: string | null;
 };
 
 export function DownloadUnlockedCard({
@@ -17,23 +20,44 @@ export function DownloadUnlockedCard({
   receiptCopyState,
   onCopyReceiptLink,
   onDownloadReceipt,
+  onRequestDownload,
+  isDownloadRequestPending = false,
+  downloadError,
 }: DownloadUnlockedCardProps) {
   return (
     <div className="relative overflow-hidden rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-4 text-sm text-emerald-100 shadow shadow-emerald-500/20 before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.25),_transparent_65%)] before:content-['']">
       <div className="relative z-10 space-y-4">
         <p className="text-base font-semibold text-emerald-50">Download unlocked</p>
         {buildAvailable ? (
-          <a
-            href={downloadUrl}
-            className="inline-flex w-full items-center justify-center rounded-full border border-emerald-300/50 bg-gradient-to-r from-emerald-400/30 via-teal-400/20 to-cyan-500/30 px-4 py-2 text-sm font-semibold text-emerald-50 transition hover:from-emerald-400/40 hover:to-cyan-500/40"
-          >
-            Download build
-          </a>
+          downloadUrl ? (
+            <a
+              href={downloadUrl}
+              className="inline-flex w-full items-center justify-center rounded-full border border-emerald-300/50 bg-gradient-to-r from-emerald-400/30 via-teal-400/20 to-cyan-500/30 px-4 py-2 text-sm font-semibold text-emerald-50 transition hover:from-emerald-400/40 hover:to-cyan-500/40"
+            >
+              Download build
+            </a>
+          ) : onRequestDownload ? (
+            <button
+              type="button"
+              onClick={onRequestDownload}
+              disabled={isDownloadRequestPending}
+              className="inline-flex w-full items-center justify-center rounded-full border border-emerald-300/50 bg-gradient-to-r from-emerald-400/30 via-teal-400/20 to-cyan-500/30 px-4 py-2 text-sm font-semibold text-emerald-50 transition hover:from-emerald-400/40 hover:to-cyan-500/40 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isDownloadRequestPending ? "Preparing download…" : "Open download"}
+            </button>
+          ) : (
+            <p className="text-xs text-emerald-100/80">
+              Sign in to download the build instantly or use your receipt to restore it later.
+            </p>
+          )
         ) : (
           <p className="text-xs text-emerald-100/80">
             The developer hasn&apos;t uploaded a downloadable build yet. You&apos;ll be notified once it&apos;s ready.
           </p>
         )}
+        {downloadError ? (
+          <p className="text-xs text-rose-100/80">{downloadError}</p>
+        ) : null}
         {receiptLink ? (
           <ReceiptActions
             value={receiptLink}

--- a/apps/web/components/game-purchase-flow/index.tsx
+++ b/apps/web/components/game-purchase-flow/index.tsx
@@ -34,6 +34,7 @@ export function GamePurchaseFlow(props: GamePurchaseFlowProps): JSX.Element | nu
     receiptCopyState,
     downloadUnlocked,
     downloadUrl,
+    downloadError,
     receiptUrl,
     receiptLinkToCopy,
     statusMessage,
@@ -41,11 +42,13 @@ export function GamePurchaseFlow(props: GamePurchaseFlowProps): JSX.Element | nu
     handleCopyInvoice,
     handleCopyReceiptLink,
     handleDownloadReceipt,
+    handleDownloadBuild,
     handleReceiptLookupSubmit,
     prepareCheckout,
     toggleReceiptLookup,
     closeReceiptLookup,
     setManualReceiptId,
+    isDownloadRequestPending,
   } = useGamePurchaseFlow(props);
 
   useEffect(() => {
@@ -94,6 +97,9 @@ export function GamePurchaseFlow(props: GamePurchaseFlowProps): JSX.Element | nu
               receiptCopyState={receiptCopyState}
               onCopyReceiptLink={handleCopyReceiptLink}
               onDownloadReceipt={handleDownloadReceipt}
+              onRequestDownload={handleDownloadBuild ?? undefined}
+              isDownloadRequestPending={isDownloadRequestPending}
+              downloadError={downloadError}
             />
           ) : (
             <CheckoutPrompt

--- a/apps/web/lib/api/purchases.ts
+++ b/apps/web/lib/api/purchases.ts
@@ -63,6 +63,16 @@ export interface PurchaseReceipt {
   buyer: PurchaseReceiptBuyer;
 }
 
+export interface PurchaseDownloadLinkRequest {
+  user_id?: string;
+  receipt_token?: string;
+}
+
+export interface PurchaseDownloadLinkResponse {
+  download_url: string;
+  expires_at: string;
+}
+
 export async function createGameInvoice(
   gameId: string,
   payload: InvoiceCreateRequest,
@@ -133,4 +143,46 @@ export function getGameDownloadUrl(gameId: string): string {
   const normalizedId = requireTrimmedValue(gameId, "Game ID is required.");
 
   return buildApiUrl(`/v1/games/${encodeURIComponent(normalizedId)}/download`);
+}
+
+export async function createPurchaseDownloadLink(
+  purchaseId: string,
+  payload: PurchaseDownloadLinkRequest,
+): Promise<PurchaseDownloadLinkResponse> {
+  const normalizedId = requireTrimmedValue(purchaseId, "Purchase ID is required.");
+
+  const body: PurchaseDownloadLinkRequest = {};
+  if (payload.user_id) {
+    body.user_id = requireTrimmedValue(
+      payload.user_id,
+      "User ID is required to request a download link.",
+    );
+  }
+  if (payload.receipt_token) {
+    body.receipt_token = requireTrimmedValue(
+      payload.receipt_token,
+      "Receipt token is required to request a download link.",
+    );
+  }
+
+  return requestJson<PurchaseDownloadLinkResponse>(
+    `/v1/purchases/${encodeURIComponent(normalizedId)}/download-link`,
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+      cache: "no-store",
+      errorMessage: "Unable to create a download link for this purchase.",
+    },
+  );
+}
+
+export async function restorePurchaseDownload(
+  purchaseId: string,
+): Promise<PurchaseDownloadLinkResponse> {
+  const normalizedId = requireTrimmedValue(
+    purchaseId,
+    "Purchase ID is required to restore a download.",
+  );
+
+  return createPurchaseDownloadLink(normalizedId, { receipt_token: normalizedId });
 }


### PR DESCRIPTION
## Summary
- allow the purchase download endpoint to accept either an authenticated user or a receipt token so paid receipts can unlock downloads (M1 — Core Lightning Purchase Flow)
- add client helpers and UI to restore downloads directly from receipt pages and guest purchase flows
- cover receipt-restore scenarios with new API tests and mark the milestone ticket complete

## Testing
- `PYTHONPATH=src pytest tests/test_purchases.py`


------
https://chatgpt.com/codex/tasks/task_e_68df158c367c832ba5dc961039e66dac