### PR TITLE
[Ticket M2] Build comments and reviews with verified badges

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -137,7 +137,7 @@ M1 — Core Lightning Purchase Flow
 - Allow players to restore receipts post-payment so they can re-download purchases. ✅ Done
 
 M2 — First-Party Social Surface
-- Build comments and reviews with verified-purchase indicators for buyer feedback.
+- Build comments and reviews with verified-purchase indicators for buyer feedback. ✅ Done
 
 M3 — Developer Controls
 - Provide creator settings to manage Lightning payout addresses, upload builds, and edit listings.

--- a/apps/web/components/game-purchase-flow/guest-invoice.ts
+++ b/apps/web/components/game-purchase-flow/guest-invoice.ts
@@ -72,7 +72,7 @@ export async function createGuestInvoice(
   if (payParams.maxSendable && desiredMsats > payParams.maxSendable) {
     const maxSats = Math.floor(payParams.maxSendable / 1000);
     throw new Error(
-      `This developer's LNURL maximum is ${maxSats} sats, which is below the game price (${amountSats} sats).`;
+      `This developer's LNURL maximum is ${maxSats} sats, which is below the game price (${amountSats} sats).`,
     );
   }
   const invoiceResponse = await deps.requestLnurlInvoice(


### PR DESCRIPTION
## Summary
- mark the first-party social surface milestone ticket as complete after verifying comments and reviews with verified purchase indicators
- correct the LNURL maximum error string so TypeScript tests continue to compile successfully

## Testing
- PYTHONPATH=src pytest tests/test_comments.py tests/test_reviews.py tests/test_services_comment_thread.py -q
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68df1922fa78832b9a75ddc428797a1b