### PR TITLE
feat: add moderation flag submissions for M4 moderation tools

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -143,7 +143,7 @@ M3 — Developer Controls
 - Provide creator settings to manage Lightning payout addresses, upload builds, and edit listings. ✅ Done
 
 M4 — Moderation Tools
-- Deliver a lightweight admin experience with basic rate limiting to mitigate spam.
+- Deliver a lightweight admin experience with basic rate limiting to mitigate spam. ✅ Done
 
 M5 — Download Fulfillment
 - Wire up secure distribution of purchased builds via presigned storage URLs.

--- a/apps/api/src/bit_indie_api/api/v1/routes/moderation_flags.py
+++ b/apps/api/src/bit_indie_api/api/v1/routes/moderation_flags.py
@@ -1,0 +1,130 @@
+"""Player-facing moderation flag submission endpoints."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from bit_indie_api.db import get_session
+from bit_indie_api.db.models import (
+    Comment,
+    Game,
+    ModerationFlag,
+    ModerationFlagStatus,
+    ModerationTargetType,
+    Review,
+    User,
+)
+from bit_indie_api.schemas.moderation import (
+    ModerationFlagCreateRequest,
+    ModerationFlagRead,
+)
+from bit_indie_api.services.rate_limiting import (
+    FLAG_RATE_LIMIT_MAX_ITEMS,
+    FLAG_RATE_LIMIT_WINDOW_SECONDS,
+    RateLimitExceeded,
+    enforce_rate_limit,
+)
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/moderation/flags", tags=["moderation"])
+
+
+_TARGET_MODEL_MAP = {
+    ModerationTargetType.GAME: Game,
+    ModerationTargetType.COMMENT: Comment,
+    ModerationTargetType.REVIEW: Review,
+}
+
+
+def _ensure_target_exists(*, session: Session, target_type: ModerationTargetType, target_id: str) -> None:
+    """Raise an HTTP 404 error when the provided moderation target cannot be located."""
+
+    model = _TARGET_MODEL_MAP.get(target_type)
+    if model is None:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Unsupported moderation target type.")
+
+    if session.get(model, target_id) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Moderation target not found.")
+
+
+@router.post(
+    "",
+    response_model=ModerationFlagRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Submit a moderation flag",
+)
+def create_moderation_flag(
+    request: ModerationFlagCreateRequest,
+    response: Response,
+    session: Session = Depends(get_session),
+) -> ModerationFlagRead:
+    """Persist a moderation flag for games, comments, or reviews."""
+
+    user = session.get(User, request.user_id)
+    if user is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Reporting user not found.")
+
+    _ensure_target_exists(
+        session=session, target_type=request.target_type, target_id=request.target_id
+    )
+
+    existing_flag_stmt = (
+        select(ModerationFlag)
+        .where(ModerationFlag.user_id == user.id)
+        .where(ModerationFlag.target_type == request.target_type)
+        .where(ModerationFlag.target_id == request.target_id)
+        .where(ModerationFlag.status == ModerationFlagStatus.OPEN)
+        .limit(1)
+    )
+    existing_flag = session.scalar(existing_flag_stmt)
+    if existing_flag is not None:
+        response.status_code = status.HTTP_200_OK
+        return ModerationFlagRead.model_validate(existing_flag)
+
+    try:
+        enforce_rate_limit(
+            session=session,
+            model=ModerationFlag,
+            user_id=user.id,
+            window_seconds=FLAG_RATE_LIMIT_WINDOW_SECONDS,
+            max_items=FLAG_RATE_LIMIT_MAX_ITEMS,
+            action="create_moderation_flag",
+            resource_id=request.target_id,
+        )
+    except RateLimitExceeded as error:
+        logger.info(
+            "moderation_flag_rate_limit_triggered",
+            extra={
+                "user_id": user.id,
+                "target_type": request.target_type,
+                "target_id": request.target_id,
+                "retry_after_seconds": error.retry_after_seconds,
+            },
+        )
+        raise HTTPException(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Flag submission rate limit exceeded. Please wait before reporting again.",
+            headers={"Retry-After": str(error.retry_after_seconds)},
+        ) from error
+
+    flag = ModerationFlag(
+        user_id=user.id,
+        target_type=request.target_type,
+        target_id=request.target_id,
+        reason=request.reason,
+    )
+    session.add(flag)
+    session.flush()
+    session.refresh(flag)
+
+    return ModerationFlagRead.model_validate(flag)
+
+
+__all__ = ["create_moderation_flag"]
+

--- a/apps/api/src/bit_indie_api/main.py
+++ b/apps/api/src/bit_indie_api/main.py
@@ -13,9 +13,10 @@ from bit_indie_api.api.v1.routes.game_catalog import router as game_catalog_rout
 from bit_indie_api.api.v1.routes.game_drafts import router as game_drafts_router
 from bit_indie_api.api.v1.routes.game_purchases import router as game_purchases_router
 from bit_indie_api.api.v1.routes.health import router as health_router
+from bit_indie_api.api.v1.routes.moderation_flags import router as moderation_flags_router
 from bit_indie_api.api.v1.routes.purchases import router as purchases_router
-from bit_indie_api.api.v1.routes.users import router as users_router
 from bit_indie_api.api.v1.routes.reviews import router as reviews_router
+from bit_indie_api.api.v1.routes.users import router as users_router
 from bit_indie_api.core.config import get_settings
 from bit_indie_api.core.telemetry import (
     configure_telemetry,
@@ -50,6 +51,7 @@ def create_application() -> FastAPI:
     application.include_router(game_purchases_router)
     application.include_router(comments_router)
     application.include_router(reviews_router)
+    application.include_router(moderation_flags_router)
     application.include_router(purchases_router)
     return application
 

--- a/apps/api/src/bit_indie_api/schemas/moderation.py
+++ b/apps/api/src/bit_indie_api/schemas/moderation.py
@@ -95,6 +95,28 @@ class ModerationActionResponse(BaseModel):
     affected_flag_ids: list[str] = Field(default_factory=list)
 
 
+class ModerationFlagCreateRequest(BaseModel):
+    """Player-submitted report targeting games, comments, or reviews."""
+
+    user_id: str = Field(..., description="Identifier of the reporting user.")
+    target_type: ModerationTargetType
+    target_id: str
+    reason: ModerationFlagReason
+
+
+class ModerationFlagRead(BaseModel):
+    """Details about a moderation flag stored in the system."""
+
+    id: str
+    target_type: ModerationTargetType
+    target_id: str
+    reason: ModerationFlagReason
+    status: ModerationFlagStatus
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class ModerationRestoreRequest(BaseModel):
     """Administrative request to restore hidden moderated content."""
 
@@ -118,10 +140,12 @@ __all__ = [
     "FlaggedCommentSummary",
     "FlaggedGameSummary",
     "FlaggedReviewSummary",
-    "ModerationActionResponse",
-    "ModerationRestoreRequest",
     "HiddenModerationItem",
+    "ModerationActionResponse",
+    "ModerationFlagCreateRequest",
+    "ModerationFlagRead",
     "ModerationQueueItem",
     "ModerationReporter",
+    "ModerationRestoreRequest",
     "ModerationTakedownRequest",
 ]

--- a/apps/api/src/bit_indie_api/services/rate_limiting.py
+++ b/apps/api/src/bit_indie_api/services/rate_limiting.py
@@ -25,6 +25,12 @@ REVIEW_RATE_LIMIT_WINDOW_SECONDS: Final[int] = 3600
 REVIEW_RATE_LIMIT_MAX_ITEMS: Final[int] = 3
 """Maximum number of reviews a user may submit within the rate limit window."""
 
+FLAG_RATE_LIMIT_WINDOW_SECONDS: Final[int] = 3600
+"""Duration of the rolling window governing moderation flag submissions (1 hour)."""
+
+FLAG_RATE_LIMIT_MAX_ITEMS: Final[int] = 10
+"""Maximum number of moderation flags a user may submit within the rate limit window."""
+
 
 @dataclass(slots=True)
 class RateLimitExceeded(RuntimeError):
@@ -113,6 +119,8 @@ def enforce_rate_limit(
 __all__ = [
     "COMMENT_RATE_LIMIT_MAX_ITEMS",
     "COMMENT_RATE_LIMIT_WINDOW_SECONDS",
+    "FLAG_RATE_LIMIT_MAX_ITEMS",
+    "FLAG_RATE_LIMIT_WINDOW_SECONDS",
     "REVIEW_RATE_LIMIT_MAX_ITEMS",
     "REVIEW_RATE_LIMIT_WINDOW_SECONDS",
     "RateLimitExceeded",

--- a/apps/api/tests/test_moderation_flags.py
+++ b/apps/api/tests/test_moderation_flags.py
@@ -1,0 +1,275 @@
+"""Tests for the player-facing moderation flag API."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from bit_indie_api.db import Base, get_engine, reset_database_state, session_scope
+from bit_indie_api.db.models import (
+    Comment,
+    Developer,
+    Game,
+    GameStatus,
+    ModerationFlag,
+    ModerationFlagReason,
+    ModerationFlagStatus,
+    ModerationTargetType,
+    Review,
+    User,
+)
+from bit_indie_api.main import create_application
+from bit_indie_api.services.rate_limiting import FLAG_RATE_LIMIT_MAX_ITEMS
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    """Ensure each test executes against isolated database state."""
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    reset_database_state()
+    yield
+    reset_database_state()
+
+
+def _create_schema() -> None:
+    """Create ORM tables for the in-memory SQLite database."""
+
+    engine = get_engine()
+    Base.metadata.create_all(engine)
+
+
+def _build_client() -> TestClient:
+    """Return a FastAPI test client bound to a fresh application instance."""
+
+    return TestClient(create_application())
+
+
+def _create_user(*, is_admin: bool = False) -> str:
+    """Persist a user and return its identifier."""
+
+    with session_scope() as session:
+        user = User(account_identifier=f"user-{uuid.uuid4().hex}", is_admin=is_admin)
+        session.add(user)
+        session.flush()
+        return user.id
+
+
+def _create_game(*, status: GameStatus = GameStatus.DISCOVER, active: bool = True) -> str:
+    """Persist a game owned by a developer and return its identifier."""
+
+    with session_scope() as session:
+        developer_user = User(account_identifier=f"dev-{uuid.uuid4().hex}")
+        session.add(developer_user)
+        session.flush()
+
+        developer = Developer(user_id=developer_user.id)
+        session.add(developer)
+        session.flush()
+
+        game = Game(
+            developer_id=developer.id,
+            title="Flaggable Game",
+            slug=f"flaggable-{uuid.uuid4().hex[:8]}",
+            status=status,
+            active=active,
+        )
+        session.add(game)
+        session.flush()
+        return game.id
+
+
+def _create_comment(game_id: str, user_id: str) -> str:
+    """Persist a comment attached to the provided game and return its identifier."""
+
+    with session_scope() as session:
+        comment = Comment(game_id=game_id, user_id=user_id, body_md="Needs review")
+        session.add(comment)
+        session.flush()
+        return comment.id
+
+
+def _create_review(game_id: str, user_id: str) -> str:
+    """Persist a review attached to the provided game and return its identifier."""
+
+    with session_scope() as session:
+        review = Review(
+            game_id=game_id,
+            user_id=user_id,
+            body_md="Suspicious content",
+            rating=1,
+        )
+        session.add(review)
+        session.flush()
+        return review.id
+
+
+def test_create_flag_requires_existing_user() -> None:
+    """The API should reject moderation flags from unknown users."""
+
+    _create_schema()
+    game_id = _create_game()
+    client = _build_client()
+
+    response = client.post(
+        "/v1/moderation/flags",
+        json={
+            "user_id": "missing-user",
+            "target_type": ModerationTargetType.GAME.value,
+            "target_id": game_id,
+            "reason": ModerationFlagReason.SPAM.value,
+        },
+    )
+
+    assert response.status_code == 404
+    assert "user" in response.json()["detail"].lower()
+
+
+def test_create_flag_requires_valid_target() -> None:
+    """Submitting a flag for a non-existent target should yield a 404 response."""
+
+    _create_schema()
+    user_id = _create_user()
+    client = _build_client()
+
+    response = client.post(
+        "/v1/moderation/flags",
+        json={
+            "user_id": user_id,
+            "target_type": ModerationTargetType.GAME.value,
+            "target_id": "missing-game",
+            "reason": ModerationFlagReason.DMCA.value,
+        },
+    )
+
+    assert response.status_code == 404
+    assert "target" in response.json()["detail"].lower()
+
+
+@pytest.mark.parametrize(
+    "target_type, factory",
+    [
+        (ModerationTargetType.GAME, _create_game),
+        (ModerationTargetType.COMMENT, _create_comment),
+        (ModerationTargetType.REVIEW, _create_review),
+    ],
+)
+def test_create_flag_persists_record(
+    target_type: ModerationTargetType,
+    factory,
+) -> None:
+    """Valid submissions should persist moderation flags for each target type."""
+
+    _create_schema()
+    reporter_id = _create_user()
+    subject_user = _create_user()
+    game_id = _create_game()
+
+    if target_type is ModerationTargetType.GAME:
+        target_id = game_id
+    else:
+        target_id = factory(game_id, subject_user)
+
+    client = _build_client()
+    response = client.post(
+        "/v1/moderation/flags",
+        json={
+            "user_id": reporter_id,
+            "target_type": target_type.value,
+            "target_id": target_id,
+            "reason": ModerationFlagReason.SPAM.value,
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["target_type"] == target_type.value
+    assert body["target_id"] == target_id
+    assert body["reason"] == ModerationFlagReason.SPAM.value
+    assert body["status"] == ModerationFlagStatus.OPEN.value
+
+    with session_scope() as session:
+        stored = session.scalar(select(ModerationFlag).where(ModerationFlag.id == body["id"]))
+        assert stored is not None
+        assert stored.user_id == reporter_id
+        assert stored.target_id == target_id
+
+
+def test_create_flag_is_idempotent_for_open_flags() -> None:
+    """Submitting a duplicate flag should return the existing open flag."""
+
+    _create_schema()
+    reporter_id = _create_user()
+    offender_id = _create_user()
+    game_id = _create_game()
+    comment_id = _create_comment(game_id, offender_id)
+
+    with session_scope() as session:
+        existing = ModerationFlag(
+            user_id=reporter_id,
+            target_type=ModerationTargetType.COMMENT,
+            target_id=comment_id,
+            reason=ModerationFlagReason.SPAM,
+        )
+        session.add(existing)
+        session.flush()
+        existing_id = existing.id
+
+    client = _build_client()
+    response = client.post(
+        "/v1/moderation/flags",
+        json={
+            "user_id": reporter_id,
+            "target_type": ModerationTargetType.COMMENT.value,
+            "target_id": comment_id,
+            "reason": ModerationFlagReason.MALWARE.value,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == existing_id
+    assert body["reason"] == ModerationFlagReason.SPAM.value
+
+
+def test_create_flag_enforces_rate_limit() -> None:
+    """Users exceeding the flag rate limit should receive a 429 response."""
+
+    _create_schema()
+    reporter_id = _create_user()
+    offender_id = _create_user()
+    game_id = _create_game()
+    now = datetime.now(timezone.utc)
+
+    with session_scope() as session:
+        for index in range(FLAG_RATE_LIMIT_MAX_ITEMS):
+            flag = ModerationFlag(
+                user_id=reporter_id,
+                target_type=ModerationTargetType.GAME,
+                target_id=f"game-{index}",
+                reason=ModerationFlagReason.SPAM,
+                created_at=now - timedelta(seconds=index + 1),
+            )
+            session.add(flag)
+
+    comment_id = _create_comment(game_id, offender_id)
+
+    client = _build_client()
+    response = client.post(
+        "/v1/moderation/flags",
+        json={
+            "user_id": reporter_id,
+            "target_type": ModerationTargetType.COMMENT.value,
+            "target_id": comment_id,
+            "reason": ModerationFlagReason.TOS.value,
+        },
+    )
+
+    assert response.status_code == 429
+    assert "rate limit" in response.json()["detail"].lower()
+    assert "Retry-After" in response.headers
+

--- a/apps/web/components/game-detail/comments-section.tsx
+++ b/apps/web/components/game-detail/comments-section.tsx
@@ -6,6 +6,7 @@ import {
   getCommentAuthorLabel,
   getCommentParagraphs,
 } from "./utils";
+import { FlagContentButton } from "./flag-content-button";
 
 type GameCommentsSectionProps = {
   gameTitle: string;
@@ -82,6 +83,7 @@ export function GameCommentsSection({
                     <p key={`${comment.id}-paragraph-${index}`}>{paragraph}</p>
                   ))}
                 </div>
+                <FlagContentButton targetType="COMMENT" targetId={comment.id} />
               </article>
             );
           })}

--- a/apps/web/components/game-detail/flag-content-button.tsx
+++ b/apps/web/components/game-detail/flag-content-button.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  type ModerationFlagPayload,
+  type ModerationFlagReason,
+  type ModerationTargetType,
+  submitModerationFlag,
+} from "../../lib/api";
+import {
+  USER_PROFILE_STORAGE_EVENT,
+  loadStoredUserProfile,
+} from "../../lib/user-storage";
+
+const reasonOptions: { value: ModerationFlagReason; label: string }[] = [
+  { value: "SPAM", label: "Spam or unsolicited promotion" },
+  { value: "TOS", label: "Terms of service violation" },
+  { value: "DMCA", label: "Copyright or DMCA issue" },
+  { value: "MALWARE", label: "Malware or security risk" },
+];
+
+type FlagContentButtonProps = {
+  targetType: ModerationTargetType;
+  targetId: string;
+};
+
+export function FlagContentButton({ targetType, targetId }: FlagContentButtonProps): JSX.Element {
+  const [profile, setProfile] = useState(() => loadStoredUserProfile());
+  const [reason, setReason] = useState<ModerationFlagReason>("SPAM");
+  const [status, setStatus] = useState<"idle" | "submitting" | "success">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    function handleProfileChange() {
+      setProfile(loadStoredUserProfile());
+    }
+
+    window.addEventListener(USER_PROFILE_STORAGE_EVENT, handleProfileChange);
+    return () => window.removeEventListener(USER_PROFILE_STORAGE_EVENT, handleProfileChange);
+  }, []);
+
+  useEffect(() => {
+    if (!profile) {
+      setStatus("idle");
+      setFeedback(null);
+      setError(null);
+    }
+  }, [profile]);
+
+  const reasonLabel = useMemo(() => {
+    return reasonOptions.find((option) => option.value === reason)?.label ?? "Spam or unsolicited promotion";
+  }, [reason]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!profile) {
+      setError("Sign in to report this content to Bit Indie moderators.");
+      return;
+    }
+
+    const payload: ModerationFlagPayload = {
+      user_id: profile.id,
+      target_type: targetType,
+      target_id: targetId,
+      reason,
+    };
+
+    setStatus("submitting");
+    setFeedback(null);
+    setError(null);
+
+    try {
+      await submitModerationFlag(payload);
+      setStatus("success");
+      setFeedback("Report submitted. Thanks for helping moderate the community.");
+    } catch (unknownError) {
+      setStatus("idle");
+      if (unknownError instanceof Error) {
+        setError(unknownError.message);
+      } else {
+        setError("Unable to submit the moderation report right now.");
+      }
+    }
+  }, [profile, targetType, targetId, reason]);
+
+  return (
+    <div className="mt-4 space-y-2 text-xs text-[#b8ffe5]/70">
+      <div className="flex flex-wrap items-center gap-3">
+        <label htmlFor={`${targetId}-flag-reason`} className="sr-only">
+          Select a report reason
+        </label>
+        <select
+          id={`${targetId}-flag-reason`}
+          className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-[#0f1f1a] focus:border-emerald-300 focus:outline-none"
+          value={reason}
+          onChange={(event) => setReason(event.target.value as ModerationFlagReason)}
+          disabled={status === "success"}
+        >
+          {reasonOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void handleSubmit()}
+          disabled={status === "submitting" || status === "success"}
+          className="inline-flex items-center justify-center rounded-full border border-rose-400/40 bg-rose-500/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-rose-100 transition hover:bg-rose-500/30 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status === "submitting" ? "Reporting…" : status === "success" ? "Reported" : "Report"}
+        </button>
+        <span className="text-[11px] text-[#dcfff2]/60">{reasonLabel}</span>
+      </div>
+      {feedback ? <p className="text-[11px] text-emerald-200">{feedback}</p> : null}
+      {error ? <p className="text-[11px] text-rose-200">{error}</p> : null}
+      {!profile && !error ? (
+        <p className="text-[11px] text-[#dcfff2]/60">Sign in to report inappropriate content.</p>
+      ) : null}
+    </div>
+  );
+}
+

--- a/apps/web/components/game-detail/reviews-section.tsx
+++ b/apps/web/components/game-detail/reviews-section.tsx
@@ -3,6 +3,7 @@ import { formatDateLabel } from "../../lib/format";
 
 import { ReviewBadge } from "./review-badge";
 import { getReviewParagraphs } from "./utils";
+import { FlagContentButton } from "./flag-content-button";
 
 type GameReviewsSectionProps = {
   gameTitle: string;
@@ -82,6 +83,7 @@ export function GameReviewsSection({
                     <p key={`${review.id}-paragraph-${index}`}>{paragraph}</p>
                   ))}
                 </div>
+                <FlagContentButton targetType="REVIEW" targetId={review.id} />
               </article>
             );
           })}


### PR DESCRIPTION
## Summary
- implement a player-facing `/v1/moderation/flags` endpoint with per-user rate limiting to satisfy M4 moderation tooling
- extend moderation schemas plus web API helpers and UI so players can report comments and reviews from the game page
- cover the new workflow with pytest regression tests and mark the M4 milestone as complete in the build plan

## Testing
- PYTHONPATH=src pytest tests/test_moderation_flags.py
- yarn lint *(fails: requires local yarn install)*

------
https://chatgpt.com/codex/tasks/task_e_68df1f0ca5a8832b826369610c611891