### PR TITLE
M5: secure presigned download delivery

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -146,7 +146,7 @@ M4 — Moderation Tools
 - Deliver a lightweight admin experience with basic rate limiting to mitigate spam. ✅ Done
 
 M5 — Download Fulfillment
-- Wire up secure distribution of purchased builds via presigned storage URLs.
+- Wire up secure distribution of purchased builds via presigned storage URLs. ✅ Done
 
 M6 — Operational Readiness
 - Round out telemetry with health endpoints, structured logging/tracing, and refreshed README/runbooks documenting the Lightning-first architecture and the removal of legacy social features.


### PR DESCRIPTION
## Summary
- attach sanitized Content-Disposition headers when generating presigned downloads
- extend storage service tests to cover header behaviour and edge cases
- mark the M5 download fulfillment ticket as complete in the MVP plan

## Testing
- PYTHONPATH=src pytest tests/test_storage_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68df2411bd7c832b988361a620e961f2