### PR TITLE
feat: add API structured logging for M6 operational readiness

### DIFF
--- a/MVPBUILDPLAN.MD
+++ b/MVPBUILDPLAN.MD
@@ -149,7 +149,7 @@ M5 — Download Fulfillment
 - Wire up secure distribution of purchased builds via presigned storage URLs. ✅ Done
 
 M6 — Operational Readiness
-- Round out telemetry with health endpoints, structured logging/tracing, and refreshed README/runbooks documenting the Lightning-first architecture and the removal of legacy social features.
+- Round out telemetry with health endpoints, structured logging/tracing, and refreshed README/runbooks documenting the Lightning-first architecture and the removal of legacy social features. ✅ Done
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ MVP feature flags:
 
 - The catalog pulls real data from the FastAPI backend; run the Docker seed script to explore the full storefront.
 
+### Observability quick start
+
+- API logs are emitted as structured JSON and include the `X-Request-ID` correlation header by default. Override the header name
+  with `REQUEST_ID_HEADER` if your ingress already sets a different identifier.
+- The request logger captures method, path, status code, latency, and client IP so you can stream metrics into your preferred
+  log pipeline without additional adapters.
+- Keep uptime checks pointed at `/health`; FastAPI returns `{ "status": "ok" }` when the service is ready.
+
 ### Full-stack dev loop
 
 - Start the full stack (Postgres, MinIO, FastAPI + Web) with seeded data and hot reload for Web:

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -12,6 +12,13 @@ docker compose -f infra/docker-compose.yml up --build
 
 The API listens on [http://localhost:8080](http://localhost:8080) and exposes a simple health endpoint at `/health`.
 
+### Observability
+
+- Logs are JSON formatted and capture the `X-Request-ID` correlation header. Provide a custom header name with the
+  `REQUEST_ID_HEADER` environment variable when your ingress forwards a different identifier.
+- Request lifecycle logs include method, path, response code, latency (ms), and client IP, making it easy to ship metrics from
+  your log pipeline.
+
 ### Seed demo data
 
 - When running via Docker (`./scripts/dev_bootstrap.sh`), migrations and the `seed_simple_mvp` script run automatically. Disable by setting `RUN_SIMPLE_MVP_SEED=0` in `infra/docker-compose.yml`.

--- a/apps/api/RUNBOOKS.md
+++ b/apps/api/RUNBOOKS.md
@@ -11,6 +11,9 @@ Recommended basic telemetry:
 - Request latency and error rate by route.
 - Database connection pool saturation and slow queries.
 - Storage (S3/R2) errors and presign latency.
+- Structured logs stream as JSON and embed the correlation header (`X-Request-ID` by default). Use this identifier to stitch
+  together reverse-proxy access logs, application traces, and payment provider webhooks. Override the header name via
+  `REQUEST_ID_HEADER` when the edge terminates a different key.
 
 ## Purchase Flow Issues
 

--- a/apps/api/src/bit_indie_api/core/logging.py
+++ b/apps/api/src/bit_indie_api/core/logging.py
@@ -1,0 +1,283 @@
+"""Structured logging utilities and middleware for the API service."""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.config
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Final, Iterator
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+
+_REQUEST_ID_CONTEXT: ContextVar[str | None] = ContextVar("request_id", default=None)
+_LOGGING_CONFIGURED: bool = False
+
+DEFAULT_LOG_LEVEL: Final[str] = "INFO"
+DEFAULT_REQUEST_ID_HEADER: Final[str] = "X-Request-ID"
+_RESERVED_LOG_RECORD_FIELDS: Final[set[str]] = {
+    "name",
+    "msg",
+    "args",
+    "levelname",
+    "levelno",
+    "pathname",
+    "filename",
+    "module",
+    "exc_info",
+    "exc_text",
+    "stack_info",
+    "lineno",
+    "funcName",
+    "created",
+    "msecs",
+    "relativeCreated",
+    "thread",
+    "threadName",
+    "processName",
+    "process",
+    "message",
+}
+
+
+def _json_default(value: Any) -> Any:
+    """Serialize objects that ``json.dumps`` does not support natively."""
+
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_default(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_default(item) for item in value]
+    return str(value)
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Formatter that renders log records as structured JSON payloads."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Return the JSON encoded representation for ``record``."""
+
+        record.message = record.getMessage()
+        payload: dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.message,
+        }
+
+        request_id = get_request_id()
+        if request_id:
+            payload["request_id"] = request_id
+
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _RESERVED_LOG_RECORD_FIELDS and not key.startswith("_")
+        }
+        if extras:
+            payload.update(extras)
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = record.stack_info
+
+        return json.dumps(payload, default=_json_default, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class LoggingSettings:
+    """Configuration describing the API logging behaviour."""
+
+    level: str
+    request_id_header: str
+
+    @classmethod
+    def from_environment(cls) -> "LoggingSettings":
+        """Construct logging settings based on environment variables."""
+
+        configured_level = (os.getenv("LOG_LEVEL") or DEFAULT_LOG_LEVEL).strip().upper()
+        if configured_level not in logging.getLevelNamesMapping():
+            configured_level = DEFAULT_LOG_LEVEL
+
+        header = (os.getenv("REQUEST_ID_HEADER") or DEFAULT_REQUEST_ID_HEADER).strip()
+        if not header:
+            header = DEFAULT_REQUEST_ID_HEADER
+
+        return cls(level=configured_level, request_id_header=header)
+
+
+@lru_cache(maxsize=1)
+def get_logging_settings() -> LoggingSettings:
+    """Return cached logging settings for reuse across the application."""
+
+    return LoggingSettings.from_environment()
+
+
+def clear_logging_settings_cache() -> None:
+    """Reset cached logging settings. Intended for unit tests."""
+
+    get_logging_settings.cache_clear()
+
+
+def configure_logging(settings: LoggingSettings) -> None:
+    """Initialize structured logging for the API service."""
+
+    global _LOGGING_CONFIGURED
+
+    if _LOGGING_CONFIGURED:
+        return
+
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "json": {"()": "bit_indie_api.core.logging.JsonLogFormatter"},
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+            }
+        },
+        "root": {
+            "handlers": ["default"],
+            "level": settings.level,
+        },
+        "loggers": {
+            "bit_indie": {
+                "handlers": ["default"],
+                "level": settings.level,
+                "propagate": False,
+            },
+            "uvicorn": {
+                "handlers": ["default"],
+                "level": settings.level,
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "handlers": ["default"],
+                "level": settings.level,
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["default"],
+                "level": settings.level,
+                "propagate": False,
+            },
+        },
+    }
+
+    logging.config.dictConfig(logging_config)
+    _LOGGING_CONFIGURED = True
+
+
+def get_request_id() -> str | None:
+    """Return the request identifier bound to the current context."""
+
+    return _REQUEST_ID_CONTEXT.get()
+
+
+@contextmanager
+def bind_request_id(request_id: str) -> Iterator[None]:
+    """Bind ``request_id`` to the active context for the duration of the block."""
+
+    token = _REQUEST_ID_CONTEXT.set(request_id)
+    try:
+        yield
+    finally:
+        _REQUEST_ID_CONTEXT.reset(token)
+
+
+def _generate_request_id() -> str:
+    """Return a new opaque request identifier."""
+
+    return uuid.uuid4().hex
+
+
+def _normalize_header(header_name: str) -> str:
+    """Return a canonical header name for internal lookups."""
+
+    return "-".join(part.capitalize() for part in header_name.split("-"))
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Middleware that attaches a request identifier to each request lifecycle."""
+
+    def __init__(self, app: ASGIApp, *, header_name: str = DEFAULT_REQUEST_ID_HEADER) -> None:
+        super().__init__(app)
+        self._header_name = _normalize_header(header_name)
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        """Attach a request identifier and propagate it to the response headers."""
+
+        incoming_request_id = request.headers.get(self._header_name)
+        request_id = incoming_request_id or _generate_request_id()
+        token: Token[str | None] = _REQUEST_ID_CONTEXT.set(request_id)
+
+        try:
+            response = await call_next(request)
+        finally:
+            _REQUEST_ID_CONTEXT.reset(token)
+
+        response.headers.setdefault(self._header_name, request_id)
+        return response
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware emitting structured request lifecycle logs."""
+
+    def __init__(self, app: ASGIApp, *, logger: logging.Logger | None = None) -> None:
+        super().__init__(app)
+        self._logger = logger or logging.getLogger("bit_indie.request")
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        """Log a structured entry once the request has completed."""
+
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration_ms = (time.perf_counter() - start) * 1_000
+
+        payload = {
+            "method": request.method,
+            "path": request.url.path,
+            "status_code": response.status_code,
+            "duration_ms": round(duration_ms, 3),
+        }
+
+        if request.client and request.client.host:
+            payload["client_ip"] = request.client.host
+
+        request_id = get_request_id()
+        if request_id:
+            payload["request_id"] = request_id
+
+        if request.query_params:
+            payload["query"] = str(request.query_params)
+
+        self._logger.info("request.completed", extra={"http": payload})
+        return response
+
+
+__all__ = [
+    "JsonLogFormatter",
+    "LoggingSettings",
+    "RequestContextMiddleware",
+    "RequestLoggingMiddleware",
+    "bind_request_id",
+    "clear_logging_settings_cache",
+    "configure_logging",
+    "get_logging_settings",
+    "get_request_id",
+]
+

--- a/apps/api/src/bit_indie_api/main.py
+++ b/apps/api/src/bit_indie_api/main.py
@@ -18,6 +18,12 @@ from bit_indie_api.api.v1.routes.purchases import router as purchases_router
 from bit_indie_api.api.v1.routes.reviews import router as reviews_router
 from bit_indie_api.api.v1.routes.users import router as users_router
 from bit_indie_api.core.config import get_settings
+from bit_indie_api.core.logging import (
+    RequestContextMiddleware,
+    RequestLoggingMiddleware,
+    configure_logging,
+    get_logging_settings,
+)
 from bit_indie_api.core.telemetry import (
     configure_telemetry,
     get_telemetry_settings,
@@ -27,6 +33,8 @@ from bit_indie_api.core.telemetry import (
 def create_application() -> FastAPI:
     """Build and configure the FastAPI application instance."""
 
+    logging_settings = get_logging_settings()
+    configure_logging(logging_settings)
     settings = get_settings()
     telemetry_settings = get_telemetry_settings()
     configure_telemetry(telemetry_settings)
@@ -39,6 +47,11 @@ def create_application() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    application.add_middleware(
+        RequestContextMiddleware,
+        header_name=logging_settings.request_id_header,
+    )
+    application.add_middleware(RequestLoggingMiddleware)
     application.include_router(auth_router)
     application.include_router(health_router)
     application.include_router(admin_router)

--- a/apps/api/tests/test_core_logging.py
+++ b/apps/api/tests/test_core_logging.py
@@ -1,0 +1,135 @@
+"""Tests for the structured logging helpers and middleware."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Iterator
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from bit_indie_api.core.logging import (
+    JsonLogFormatter,
+    RequestContextMiddleware,
+    RequestLoggingMiddleware,
+    bind_request_id,
+    clear_logging_settings_cache,
+    configure_logging,
+    get_logging_settings,
+    get_request_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_logging_environment(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Ensure logging configuration caches are cleared before each test."""
+
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.delenv("REQUEST_ID_HEADER", raising=False)
+    clear_logging_settings_cache()
+    monkeypatch.setattr("bit_indie_api.core.logging._LOGGING_CONFIGURED", False, raising=False)
+    yield
+
+
+def test_json_formatter_renders_structured_output() -> None:
+    """Structured formatter should include request id and extras."""
+
+    formatter = JsonLogFormatter()
+    record = logging.LogRecord(
+        name="bit_indie.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=42,
+        msg="processed %s",
+        args=("event",),
+        exc_info=None,
+    )
+    record.metrics = {"counter": 1}
+
+    with bind_request_id("req-123"):
+        serialized = formatter.format(record)
+
+    payload = json.loads(serialized)
+    assert payload["message"] == "processed event"
+    assert payload["level"] == "INFO"
+    assert payload["request_id"] == "req-123"
+    assert payload["metrics"] == {"counter": 1}
+
+
+def test_request_context_middleware_generates_request_id() -> None:
+    """Middleware should populate the context when the header is absent."""
+
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+
+    @app.get("/probe")
+    def probe() -> dict[str, str | None]:
+        return {"request_id": get_request_id()}
+
+    client = TestClient(app)
+    response = client.get("/probe")
+    assert response.status_code == 200
+    generated_id = response.headers["X-Request-ID"]
+    assert generated_id
+    assert response.json()["request_id"] == generated_id
+
+
+def test_request_context_middleware_preserves_header() -> None:
+    """Existing request identifiers should flow through responses unchanged."""
+
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+
+    @app.get("/probe")
+    def probe() -> dict[str, str | None]:
+        return {"request_id": get_request_id()}
+
+    client = TestClient(app)
+    response = client.get("/probe", headers={"X-Request-ID": "external"})
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"] == "external"
+    assert response.json()["request_id"] == "external"
+
+
+def test_request_logging_middleware_emits_structured_logs() -> None:
+    """Requests should produce structured completion logs."""
+
+    app = FastAPI()
+    settings = get_logging_settings()
+    configure_logging(settings)
+    app.add_middleware(RequestContextMiddleware)
+    app.add_middleware(RequestLoggingMiddleware)
+
+    @app.get("/status")
+    def status() -> dict[str, str]:
+        return {"ok": "true"}
+
+    client = TestClient(app)
+    captured: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+            """Collect log records for assertions."""
+
+            captured.append(record)
+
+    handler = _ListHandler()
+    logger = logging.getLogger("bit_indie.request")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    try:
+        response = client.get("/status")
+    finally:
+        logger.removeHandler(handler)
+
+    assert response.status_code == 200
+    assert captured, "Expected request log record to be emitted"
+    record = captured[-1]
+    assert record.message == "request.completed"
+    assert isinstance(record.http, dict)
+    assert record.http["status_code"] == 200
+    assert record.http["method"] == "GET"
+    assert record.http["path"] == "/status"
+    assert record.http["duration_ms"] >= 0


### PR DESCRIPTION
## Summary
- implement JSON logging utilities and request context middleware for the FastAPI service (M6)
- document the new observability workflow and mark the operational readiness ticket complete

## Testing
- PYTHONPATH=apps/api/src pytest apps/api/tests/test_core_logging.py apps/api/tests/test_api_health.py

------
https://chatgpt.com/codex/tasks/task_e_68df25ec5840832ba7522955cd624e98