### PR TITLE
refactor: remove obsolete review helper

### DIFF
--- a/apps/web/components/game-detail/utils.ts
+++ b/apps/web/components/game-detail/utils.ts
@@ -21,10 +21,6 @@ export function getDescriptionParagraphs(description: string | null): string[] {
   return splitIntoParagraphs(description);
 }
 
-export function getReviewParagraphs(body: string): string[] {
-  return splitIntoParagraphs(body);
-}
-
 export function getCommentParagraphs(body: string): string[] {
   return splitIntoParagraphs(body);
 }

--- a/apps/web/lib/hooks/use-stored-user-profile.ts
+++ b/apps/web/lib/hooks/use-stored-user-profile.ts
@@ -19,9 +19,8 @@ export function useStoredUserProfile(): UserProfile | null {
   const isClient = typeof window !== "undefined";
   const { data } = useQuery<UserProfile | null>({
     queryKey: USER_PROFILE_QUERY_KEY,
-    queryFn: async () => loadStoredUserProfile(),
-    initialData: null,
-    enabled: isClient,
+    queryFn: isClient ? () => loadStoredUserProfile() : undefined,
+    initialData: () => null,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove the unused review paragraph helper so comments no longer expose review-specific helpers
- align the stored profile query with the lightweight query client by using an initial data factory and skipping server execution on the server

## Testing
- npm run test --workspace apps/web

------
https://chatgpt.com/codex/tasks/task_e_68e0ae8448cc832b88140e8e5a78a081