### PR TITLE
fix: stabilize user profile query

### DIFF
--- a/apps/web/lib/hooks/use-stored-user-profile.ts
+++ b/apps/web/lib/hooks/use-stored-user-profile.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
 import type { UserProfile } from "../api";
 import { useQuery, useQueryClient } from "../react-query";
@@ -17,9 +17,10 @@ import { USER_PROFILE_QUERY_KEY } from "../user-session";
 export function useStoredUserProfile(): UserProfile | null {
   const queryClient = useQueryClient();
   const isClient = typeof window !== "undefined";
+  const readProfileFromStorage = useCallback(() => loadStoredUserProfile(), []);
   const { data } = useQuery<UserProfile | null>({
     queryKey: USER_PROFILE_QUERY_KEY,
-    queryFn: isClient ? () => loadStoredUserProfile() : undefined,
+    queryFn: isClient ? readProfileFromStorage : undefined,
     initialData: () => null,
   });
 


### PR DESCRIPTION
## Summary
- memoize the stored user profile query function so it stops recreating per render
- prevent the client provider from repeatedly re-reading localStorage and freezing signed-in sessions

## Testing
- yarn lint *(fails: workspace package missing from lockfile in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12687162c832b876367dce6ecf5b9